### PR TITLE
Streamline VS Code settings to just project requirements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,61 +1,8 @@
 {
-  "[json]": {
-    "editor.formatOnSave": true
-  },
-  "[ruby]": {
-    "editor.defaultFormatter": "testdouble.vscode-standard-ruby",
-    "editor.formatOnSave": true,
-    "editor.formatOnType": true,
-    "editor.inlineSuggest.enabled": true,
-    "editor.semanticHighlighting.enabled": true,
-    "editor.tabSize": 2
-  },
-  "[yaml]": {
-    "editor.defaultFormatter": "redhat.vscode-yaml",
-    "editor.tabSize": 2
-  },
-  "editor.bracketPairColorization.enabled": true,
-  "editor.defaultFormatter": "testdouble.vscode-standard-ruby",
-  "editor.fontLigatures": true,
-  "editor.fontSize": 16,
-  "editor.formatOnSave": true,
-  "editor.formatOnType": true,
-  "editor.inlineSuggest.enabled": true,
-  "editor.quickSuggestions": {
-    "strings": "on"
-  },
-  "editor.semanticHighlighting.enabled": true,
   "editor.tabSize": 2,
-  "editor.lineHeight": 24,
-  "files.associations": {
-    "*.css": "tailwindcss",
-    "*.scss": "tailwindcss"
-  },
-  "files.autoSave": "onFocusChange",
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "git.autofetch": true,
-  "git.confirmSync": false,
-  "git.ignoreRebaseWarning": true,
-  "less.format.spaceAroundSelectorSeparator": true,
-  "scss.format.spaceAroundSelectorSeparator": true,
-  "solargraph.autoformat": true,
-  "solargraph.definitions": true,
-  "solargraph.diagnostics": true,
-  "solargraph.formatting": true,
-  "solargraph.useBundler": true,
-  "standardRuby.mode": "enableViaGemfile",
-  "terminal.integrated.env.osx": {
-    "PATH": "${env:PATH}"
-  },
-  "terminal.integrated.fontSize": 15,
-  "window.title": "${activeFolderMedium} ${activeEditorShort}${separator}${rootName}${separator}${profileName}",
-  "workbench.startupEditor": "none",
-  "yaml.format.enable": true,
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
   "peacock.color": "#8D5EB7",
   "workbench.colorCustomizations": {
     "activityBar.activeBackground": "#a681c7",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,9 +1,10 @@
 {
   "version": "2.0.0",
-  "command": "bundle",
   "tasks": [
     {
       "label": "bundle install",
+      "type": "shell",
+      "command": "bundle",
       "args": [
         "install"
       ],
@@ -23,9 +24,8 @@
     },
     {
       "label": "bundle update",
-      "args": [
-        "update"
-      ],
+      "type": "shell",
+      "command": "bundle update",
       "options": {
         "cwd": "${workspaceFolder}"
       },
@@ -42,12 +42,8 @@
     },
     {
       "label": "Run YARD server",
-      "args": [
-        "exec",
-        "yard",
-        "server",
-        "--reload"
-      ],
+      "type": "shell",
+      "command": "bundle exec yard server --reload",
       "options": {
         "cwd": "${workspaceFolder}"
       },
@@ -66,11 +62,8 @@
     },
     {
       "label": "Build admin assets",
-      "args": [
-        "exec",
-        "rake",
-        "panda_cms:assets:watch_admin"
-      ],
+      "type": "shell",
+      "command": "bundle exec rake panda_cms:assets:watch_admin",
       "options": {
         "cwd": "${workspaceFolder}"
       },
@@ -88,11 +81,9 @@
       }
     },
     {
-      "label": "RSpec (all files)",
-      "args": [
-        "exec",
-        "rspec"
-      ],
+      "label": "Run tests",
+      "type": "shell",
+      "command": "bundle exec rspec",
       "options": {
         "cwd": "${workspaceFolder}"
       },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ When creating new branches, please use the following format: `prefix/name-of-bra
 * `dep` – dependency updates, e.g. gem updates or similar
 * `release` - a new release of the gem
 * `ux` - frontend changes that do not fit into the categories above
+* `devex` - developer experience (e.g. IDEs, scripts, etc.)
 
 If available, include the ID of the Github issue in the branch, e.g. `bugfix/123-correct-timezones-on-page-edit`
 


### PR DESCRIPTION
* Streamlines VS Code settings to just those required by the project, as other settings will have collided with a developer's preference.
* Adds automagic tasks for watching Tailwind CSS (building the admin assets) and running the YARD documentation server.
* Adds optional task to run RSpec on all files.