### PR TITLE
Add GitHub pages support for docs.pandacms.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.pandacms.io


### PR DESCRIPTION
Adds the required `CNAME` file for GitHub pages support for https://docs.pandacms.io