### PR TITLE
Make post URLs and slugs render correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     panda_cms (0.5.8)
       activestorage-office-previewer (~> 0.1)
+      amazing_print (~> 1.6)
       awesome_nested_set (~> 3.7)
       aws-sdk-s3 (~> 1)
       danger (~> 9.5)
@@ -651,7 +652,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  amazing_print (~> 1.6)
   annotate (~> 3.2)
   better_errors (~> 2.10)
   binding_of_caller (~> 1.0)

--- a/app/controllers/panda_cms/admin/posts_controller.rb
+++ b/app/controllers/panda_cms/admin/posts_controller.rb
@@ -68,7 +68,7 @@ module PandaCms
       # @return PandaCms::post
       def post
         @post ||= if params[:id]
-          PandaCms::Post.find_by_slug(params[:id])
+          PandaCms::Post.find_by_slug("/" + params[:id])
         else
           PandaCms::Post.new
         end

--- a/app/controllers/panda_cms/posts_controller.rb
+++ b/app/controllers/panda_cms/posts_controller.rb
@@ -1,18 +1,11 @@
 module PandaCms
   class PostsController < ApplicationController
-    def index
-    end
-
     def show
-      post = PandaCms::Post.find_by(slug: params[:slug])
+      @posts_index_page = PandaCms::Page.find_by(path: "/#{PandaCms.posts[:prefix]}")
+      @post = PandaCms::Post.find_by(slug: "/#{params[:slug]}")
+      @title = @post.title
 
-      # TODO: Make this much nicer in future
-      globals = {
-        post: post,
-        title: post.title
-      }
-
-      render inline: "", assigns: globals, status: :ok, layout: "layouts/post"
+      render inline: "", status: :ok, layout: "layouts/post"
     end
   end
 end

--- a/app/lib/panda_cms/demo_site_generator.rb
+++ b/app/lib/panda_cms/demo_site_generator.rb
@@ -38,6 +38,9 @@ module PandaCms
       @pages[:about] = PandaCms::Page.find_or_create_by!({path: "/about", title: "About", template: @templates[:page], parent: @pages[:home]})
       @pages[:terms] = PandaCms::Page.find_or_create_by!({path: "/terms-and-conditions", title: "Terms & Conditions", template: @templates[:page], parent: @pages[:home]})
 
+      PandaCms::Page.reset_column_information
+      PandaCms::Page.rebuild!
+
       @pages
     end
 
@@ -52,7 +55,7 @@ module PandaCms
 
       # Automatically create main menu from homepage
       unless @pages[:home].nil?
-        @menus[:main].update(kind: :auto, start_page: @pages[:home])
+        @menus[:main].update(kind: :auto, start_page: @pages[:home], depth: 1)
         @menus[:main].generate_auto_menu_items
       end
 

--- a/app/models/panda_cms/post.rb
+++ b/app/models/panda_cms/post.rb
@@ -11,7 +11,13 @@ module PandaCms
     belongs_to :user, class_name: "PandaCms::User"
 
     validates :title, presence: true
-    validates :slug, presence: true, uniqueness: true, format: {with: /\A[a-z0-9-]+\z/}
+    validates :slug,
+      presence: true,
+      uniqueness: true,
+      format: {
+        with: /\A\/[a-z0-9-]+\z/,
+        message: "must start with a forward slash and contain only lowercase letters, numbers, and hyphens"
+      }
 
     scope :ordered, -> { order(published_at: :desc) }
     scope :with_user, -> { includes(:user) }
@@ -28,7 +34,7 @@ module PandaCms
     }
 
     def to_param
-      slug.to_s
+      formatted_slug.to_s
     end
 
     def excerpt(length = 100, squish: true)
@@ -42,10 +48,10 @@ module PandaCms
     end
 
     def formatted_slug
-      if params[:slug][0] != "/"
-        "/#{params[:slug]}"
+      if slug[0] == "/"
+        slug[1, slug.length].to_s
       else
-        params[:slug]
+        slug
       end
     end
   end

--- a/app/views/panda_cms/admin/posts/_form.html.erb
+++ b/app/views/panda_cms/admin/posts/_form.html.erb
@@ -10,7 +10,6 @@
     <%= f.button %>
   </div>
 <% end %>
-
 <% content_for :head do %>
   <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.8/dist/trix.css">
   <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,8 @@ PandaCms::Engine.routes.draw do
 
   if PandaCms.posts
     # TODO: Allow multiple types of post in future
-    get PandaCms.posts[:prefix], to: "posts#index", as: :posts
+    # TODO: This now requires a page to be created, make it explicit (with a rendering posts helper?)
+    # get PandaCms.posts[:prefix], to: "posts#index", as: :posts
     get "#{PandaCms.posts[:prefix]}/:slug", to: "posts#show", as: :post
   end
 

--- a/panda_cms.gemspec
+++ b/panda_cms.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0"
 
   spec.add_dependency "activestorage-office-previewer", "~> 0.1"
+  spec.add_dependency "amazing_print", "~> 1.6"
   spec.add_dependency "awesome_nested_set", "~> 3.7"
   spec.add_dependency "aws-sdk-s3", "~> 1"
   spec.add_dependency "danger", "~> 9.5"
@@ -49,7 +50,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "view_component", "~> 3.14"
   spec.add_dependency "whois-parser", "~> 2.0"
 
-  spec.add_development_dependency "amazing_print", "~> 1.6"
   spec.add_development_dependency "annotate", "~> 3.2"
   spec.add_development_dependency "better_errors", "~> 2.10"
   spec.add_development_dependency "binding_of_caller", "~> 1.0"


### PR DESCRIPTION
### Detail

This Pull Request:

* [x] Changes post URLs and slugs to be consistent everywhere, i.e. they are in the database with a preceding `/` similar to pages
* [x] Supports using custom templates (and a custom "posts index") page
* [x] Moves `amazing_print` in the `gemspec` for easier use of production consoles