### PR TITLE
Fix CI so it runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: "App Tests"
 
 "on": # yamllint disable-line rule:truthy
   pull_request:
-    branches:
-      - "*"
   push:
     branches:
       - main


### PR DESCRIPTION
### Background

Specs weren't running, apparently github doesn't accept `*` as a wildcard.