### PR TITLE
Enable CSRF protection in spec/dummy app

### DIFF
--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Potential fix for [https://github.com/tastybamboo/panda-cms/security/code-scanning/11](https://github.com/tastybamboo/panda-cms/security/code-scanning/11)

To fix the problem, we need to enable CSRF protection in the `ApplicationController`. The best practice is to call `protect_from_forgery` with the `with: :exception` option, which raises an exception if an invalid CSRF token is detected. This should be added as the first line inside the `ApplicationController` class definition. No additional imports or dependencies are required, as this is standard Rails functionality. Only the file `spec/dummy/app/controllers/application_controller.rb` needs to be changed, by adding the method call inside the class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
