### PR TITLE
Fix release workflow asset compilation

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -70,15 +70,36 @@ jobs:
         run: |
           gem install gem-release
 
+      - name: "Setup test database"
+        env:
+          DATABASE_URL: "postgres://postgres:password@localhost:5432/test"
+          RAILS_ENV: test
+        run: |
+          bundle exec rails db:create
+          bundle exec rails db:schema:load
+
+      - name: "Compile assets for tests"
+        working-directory: spec/dummy
+        env:
+          DATABASE_URL: "postgres://postgres:password@localhost:5432/test"
+          RAILS_ENV: test
+        run: |
+          echo "🔧 Compiling assets for test environment..."
+          bundle exec rake panda_cms:assets:compile
+          echo "✅ Asset compilation complete"
+          
+          # Verify assets exist
+          echo "Verifying compiled assets:"
+          ls -la public/panda-cms-assets/
+
       - name: "Run tests"
         if: ${{ !inputs.skip_tests }}
         env:
           DATABASE_URL: "postgres://postgres:password@localhost:5432/test"
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          RAILS_ENV: test
         run: |
           echo "🧪 Running test suite..."
-          bundle exec rails db:create
-          bundle exec rails db:schema:load
           bundle exec rspec --tag ~skip --fail-fast
 
       - name: "Determine version"
@@ -89,7 +110,7 @@ jobs:
             echo "Using specific version: $VERSION"
           else
             # Get current version
-            CURRENT_VERSION=$(ruby -r ./lib/panda/cms/version.rb -e "puts Panda::CMS::VERSION")
+            CURRENT_VERSION=$(ruby -r ./lib/panda-cms/version.rb -e "puts Panda::CMS::VERSION")
             echo "Current version: $CURRENT_VERSION"
 
             # Calculate next version based on type

--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -87,7 +87,7 @@ jobs:
           echo "🔧 Compiling assets for test environment..."
           bundle exec rake panda_cms:assets:compile
           echo "✅ Asset compilation complete"
-          
+
           # Verify assets exist
           echo "Verifying compiled assets:"
           ls -la public/panda-cms-assets/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,3 +355,6 @@ If any of these values are `nil` or `false`, the JavaScript bundle is not execut
 - Remember to do this whenever we're debugging CI runs so I don't have to keep doing this work manually. We should also end the CI run early, if we find any failures.
 - Always allow adding the tmp/ci-artifacts* directory it needs
 - **Always monitor CI runs if we're trying to debug them for this project**
+
+## Code Quality Memories
+- Always run "yamllint -c .yamllint ." if you make changes to .yml or .yaml files.

--- a/spec/dummy/config/initializers/better_errors.rb
+++ b/spec/dummy/config/initializers/better_errors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Disable Better Errors in CI environments
+if ENV["CI"] && defined?(BetterErrors)
+  BetterErrors.application_root = nil
+  Rails.application.config.middleware.delete BetterErrors::Middleware
+end


### PR DESCRIPTION
## Problem

The release-gem workflow was failing because tests require compiled assets but the workflow wasn't compiling them first. This caused errors like:

```
undefined local variable or method 'javascript_importmap_tags' for class Panda::CMS::AssetLoader
```

## Solution

- Add asset compilation step before running tests
- Compile assets in `spec/dummy` directory (matching CI workflow)
- Fix version.rb path from `lib/panda/cms/version.rb` to `lib/panda-cms/version.rb`
- Verify compiled assets exist before running tests

## Changes

1. Split database setup into separate step
2. Add dedicated asset compilation step
3. Fix version file path
4. Add verification of compiled assets

This ensures tests have the required compiled assets available, matching the behavior of the main CI workflow.