### PR TITLE
Fix root_path error in ApplicationController

### DIFF
--- a/app/controllers/panda/cms/application_controller.rb
+++ b/app/controllers/panda/cms/application_controller.rb
@@ -39,7 +39,7 @@ module Panda
       end
 
       def authenticate_user!
-        redirect_to root_path, flash: {error: "Please login to view this!"} unless user_signed_in?
+        redirect_to main_app.root_path, flash: {error: "Please login to view this!"} unless user_signed_in?
       end
 
       def authenticate_admin_user!


### PR DESCRIPTION
## Problem

The ApplicationController's `authenticate_user\!` method was using `root_path` which is not available in the Rails engine context, causing:

```
NameError: undefined local variable or method 'root_path' for an instance of Panda::CMS::FormSubmissionsController
```

## Solution

Use `main_app.root_path` instead of bare `root_path`. In Rails engines, routes from the host application must be prefixed with `main_app`.

## Changes

- Updated `authenticate_user\!` method to use `main_app.root_path`
- This properly references the host application's root route

This fixes the error when controllers inherit from ApplicationController and trigger the authentication redirect.