### PR TITLE
Fix bundle frozen mode error in release workflow

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -168,8 +168,11 @@ jobs:
           VERSION_FILE="lib/panda-cms/version.rb"
           sed -i "s/VERSION = \".*\"/VERSION = \"${{ steps.version.outputs.VERSION }}\"/" $VERSION_FILE
 
+          # Disable frozen mode for bundle update
+          bundle config set frozen false
+
           # Update Gemfile.lock
-          bundle update
+          bundle update panda-cms
 
       - name: "Generate changelog"
         id: changelog


### PR DESCRIPTION
## Problem

The release workflow was failing during version bump with:

```
Bundler is unlocking, but the lockfile can't be updated because frozen mode is set
```

## Root Cause

In CI environments, Bundler runs in frozen mode by default (via `bundle install --deployment` or `--frozen`). This prevents `bundle update` from modifying the Gemfile.lock.

## Solution

Add `bundle config set frozen false` before running `bundle update` to explicitly disable frozen mode for the version update step.

## Changes

- Disable frozen mode before updating Gemfile.lock
- Only update the panda-cms gem specifically (not all dependencies)

This allows the release workflow to update the gem version in Gemfile.lock as needed.