### PR TITLE
Fix test fixture symlink to use relative path

### DIFF
--- a/spec/dummy/spec/fixtures/files/test_image.png
+++ b/spec/dummy/spec/fixtures/files/test_image.png
@@ -1,1 +1,1 @@
-/Users/james/Projects/panda-cms-release/spec/fixtures/files/test_image.png
+../../../../fixtures/files/test_image.png


### PR DESCRIPTION
## Summary

- Fixed broken symlink that was pointing to an absolute development machine path

## Problem

The `spec/dummy/spec/fixtures/files/test_image.png` symlink was pointing to:
```
/Users/james/Projects/panda-cms-release/spec/fixtures/files/test_image.png
```

This absolute path doesn't exist in CI, causing 11 test failures in panda-cms-pro and any other dependent projects.

## Solution

Changed the symlink to use a relative path:
```
../../../../fixtures/files/test_image.png
```

This works in both local development and CI environments.

## Test plan

- [ ] CI passes on this PR
- [ ] panda-cms-pro CI passes after merging this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)