### PR TITLE
fix: Update PanelComponent usage to use ViewComponent slot syntax

### DIFF
--- a/app/components/panda/cms/admin/popular_pages_component.html.erb
+++ b/app/components/panda/cms/admin/popular_pages_component.html.erb
@@ -1,7 +1,7 @@
 <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
   <% panel.with_heading_slot(text: "Popular Pages (#{period_name})") %>
 
-  <% panel.body do %>
+  <% panel.with_body do %>
     <% if popular_pages.any? %>
       <div class="overflow-y-auto max-h-96">
         <table class="min-w-full divide-y divide-gray-300">

--- a/docs/developers/admin-ui.md
+++ b/docs/developers/admin-ui.md
@@ -112,8 +112,8 @@ Groups related content in a panel with optional heading.
 
 ```erb
 <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
-  <% panel.heading(text: "Panel Title", level: :panel, icon: "fa-solid fa-icon") %>
-  <% panel.body do %>
+  <% panel.with_heading_slot(text: "Panel Title", icon: "fa-solid fa-icon") %>
+  <% panel.with_body do %>
     <%# Panel content %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Summary
- Update `panel.body` to `panel.with_body` to match ViewComponent slot API
- Update documentation with new syntax
- This is a companion PR to tastybamboo/panda-core#66 (already merged)

## Test plan
- [x] PopularPagesComponent tests pass
- [ ] Verify on staging that dashboard no longer shows raw HTML tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)