### PR TITLE
fix: Remove duplicate breadcrumbs and fix panel content placement

### DIFF
--- a/app/views/panda/cms/admin/forms/edit.html.erb
+++ b/app/views/panda/cms/admin/forms/edit.html.erb
@@ -8,76 +8,79 @@
 
     <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
       <% panel.with_heading_slot(text: "Form Settings") %>
+      <% panel.with_body do %>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <%= f.text_field :name %>
+          <%= f.select :status, [["Active", "active"], ["Draft", "draft"], ["Archived", "archived"]], { label: "Status" } %>
+        </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <%= f.text_field :name %>
-        <%= f.select :status, [["Active", "active"], ["Draft", "draft"], ["Archived", "archived"]], { label: "Status" } %>
-      </div>
+        <div class="mt-4">
+          <%= f.text_area :description, rows: 2, meta: "Optional description for admin reference" %>
+        </div>
 
-      <div class="mt-4">
-        <%= f.text_area :description, rows: 2, meta: "Optional description for admin reference" %>
-      </div>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-        <%= f.text_field :completion_path, placeholder: "/thank-you", meta: "Path to redirect after submission" %>
-        <%= f.text_field :success_message, placeholder: "Thank you for your submission!", meta: "Flash message shown on success" %>
-      </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <%= f.text_field :completion_path, placeholder: "/thank-you", meta: "Path to redirect after submission" %>
+          <%= f.text_field :success_message, placeholder: "Thank you for your submission!", meta: "Flash message shown on success" %>
+        </div>
+      <% end %>
     <% end %>
 
     <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
       <% panel.with_heading_slot(text: "Form Fields") %>
-
-      <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
-        <template data-nested-form-target="template">
-          <%= f.fields_for :form_fields, Panda::CMS::FormField.new, child_index: "NEW_RECORD" do |field_form| %>
-            <%= render "form_field_row", form: field_form %>
-          <% end %>
-        </template>
-
-        <div class="space-y-4">
-          <% if form.form_fields.any? %>
-            <%= f.fields_for :form_fields, form.form_fields.ordered do |field_form| %>
+      <% panel.with_body do %>
+        <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
+          <template data-nested-form-target="template">
+            <%= f.fields_for :form_fields, Panda::CMS::FormField.new, child_index: "NEW_RECORD" do |field_form| %>
               <%= render "form_field_row", form: field_form %>
             <% end %>
-          <% end %>
-        </div>
+          </template>
 
-        <div data-nested-form-target="target"></div>
+          <div class="space-y-4">
+            <% if form.form_fields.any? %>
+              <%= f.fields_for :form_fields, form.form_fields.ordered do |field_form| %>
+                <%= render "form_field_row", form: field_form %>
+              <% end %>
+            <% end %>
+          </div>
 
-        <div class="mt-4">
-          <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Field", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>
+          <div data-nested-form-target="target"></div>
+
+          <div class="mt-4">
+            <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Field", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>
+          </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
 
     <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
       <% panel.with_heading_slot(text: "Notification Settings") %>
-
-      <div class="mt-4">
-        <%= f.text_field :notification_emails, placeholder: "admin@example.com, team@example.com", meta: "Comma-separated list of email addresses to notify on submission" %>
-      </div>
-
-      <div class="mt-4">
-        <%= f.text_field :notification_subject, placeholder: "New form submission: {{name}}", meta: "Email subject line (use {{field_name}} for dynamic values)" %>
-      </div>
-
-      <div class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
-        <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-4">Submitter Confirmation Email</h4>
-
+      <% panel.with_body do %>
         <div class="mt-4">
-          <%= f.check_box :send_confirmation, label: "Send confirmation email to submitter" %>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-          <% email_fields = form.form_fields.select { |field| field.field_type == "email" } %>
-          <%= f.select :confirmation_email_field, email_fields.map { |field| [field.label, field.name] }, { include_blank: "Select email field...", label: "Email Field", meta: "Which field contains the submitter's email?" } %>
-          <%= f.text_field :confirmation_subject, placeholder: "Thank you for contacting us" %>
+          <%= f.text_field :notification_emails, placeholder: "admin@example.com, team@example.com", meta: "Comma-separated list of email addresses to notify on submission" %>
         </div>
 
         <div class="mt-4">
-          <%= f.text_area :confirmation_body, rows: 5, placeholder: "Thank you {{name}} for your message. We will respond shortly.", meta: "Use {{field_name}} for dynamic values" %>
+          <%= f.text_field :notification_subject, placeholder: "New form submission: {{name}}", meta: "Email subject line (use {{field_name}} for dynamic values)" %>
         </div>
-      </div>
+
+        <div class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
+          <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-4">Submitter Confirmation Email</h4>
+
+          <div class="mt-4">
+            <%= f.check_box :send_confirmation, label: "Send confirmation email to submitter" %>
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+            <% email_fields = form.form_fields.select { |field| field.field_type == "email" } %>
+            <%= f.select :confirmation_email_field, email_fields.map { |field| [field.label, field.name] }, { include_blank: "Select email field...", label: "Email Field", meta: "Which field contains the submitter's email?" } %>
+            <%= f.text_field :confirmation_subject, placeholder: "Thank you for contacting us" %>
+          </div>
+
+          <div class="mt-4">
+            <%= f.text_area :confirmation_body, rows: 5, placeholder: "Thank you {{name}} for your message. We will respond shortly.", meta: "Use {{field_name}} for dynamic values" %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
 
     <div class="flex justify-end gap-x-3 border-t border-gray-200 mt-6 pt-4 dark:border-white/10">

--- a/app/views/panda/cms/admin/menus/edit.html.erb
+++ b/app/views/panda/cms/admin/menus/edit.html.erb
@@ -1,10 +1,3 @@
-<%= render Panda::Core::Admin::BreadcrumbComponent.new(
-  items: [
-    { text: "Menus", href: admin_cms_menus_path },
-    { text: @menu.name, href: edit_admin_cms_menu_path(@menu) }
-  ]
-) %>
-
 <%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
   <% component.with_heading(text: "Edit Menu: #{@menu.name}", level: 1) %>
 
@@ -21,45 +14,47 @@
       <% if @menu.kind == "static" %>
         <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
           <% panel.with_heading_slot(text: "Menu Items") %>
-
-          <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
-            <template data-nested-form-target="template">
-              <%= f.fields_for :menu_items, Panda::CMS::MenuItem.new, child_index: "NEW_RECORD" do |item_form| %>
-                <%= render "menu_item_fields", form: item_form %>
-              <% end %>
-            </template>
-
-            <div class="space-y-4">
-              <% if @menu.menu_items.any? %>
-                <%= f.fields_for :menu_items, @menu.menu_items.sort_by(&:lft) do |item_form| %>
+          <% panel.with_body do %>
+            <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
+              <template data-nested-form-target="template">
+                <%= f.fields_for :menu_items, Panda::CMS::MenuItem.new, child_index: "NEW_RECORD" do |item_form| %>
                   <%= render "menu_item_fields", form: item_form %>
                 <% end %>
-              <% end %>
-            </div>
+              </template>
 
-            <div data-nested-form-target="target"></div>
+              <div class="space-y-4">
+                <% if @menu.menu_items.any? %>
+                  <%= f.fields_for :menu_items, @menu.menu_items.sort_by(&:lft) do |item_form| %>
+                    <%= render "menu_item_fields", form: item_form %>
+                  <% end %>
+                <% end %>
+              </div>
 
-            <div class="mt-4">
-              <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Menu Item", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>
+              <div data-nested-form-target="target"></div>
+
+              <div class="mt-4">
+                <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Menu Item", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>
+              </div>
             </div>
-          </div>
+          <% end %>
         <% end %>
       <% else %>
         <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
           <% panel.with_heading_slot(text: "Auto-Generated Menu Items") %>
-
-          <% if @menu.menu_items.any? %>
-            <%= render Panda::Core::Admin::TableComponent.new(term: "menu item", rows: @menu.menu_items.root.self_and_descendants) do |table| %>
-              <% table.column("Text") do |menu_item| %>
-                <div class="<%= "ml-#{menu_item.depth * 6}" %>">
-                  <%= menu_item.text %>
-                </div>
+          <% panel.with_body do %>
+            <% if @menu.menu_items.any? %>
+              <%= render Panda::Core::Admin::TableComponent.new(term: "menu item", rows: @menu.menu_items.root.self_and_descendants) do |table| %>
+                <% table.column("Text") do |menu_item| %>
+                  <div class="<%= "ml-#{menu_item.depth * 6}" %>">
+                    <%= menu_item.text %>
+                  </div>
+                <% end %>
+                <% table.column("Page") { |menu_item| menu_item.page&.title } %>
+                <% table.column("Path") { |menu_item| menu_item.page&.path } %>
               <% end %>
-              <% table.column("Page") { |menu_item| menu_item.page&.title } %>
-              <% table.column("Path") { |menu_item| menu_item.page&.path } %>
+            <% else %>
+              <p class="text-sm text-gray-500 dark:text-gray-400">No menu items generated yet. Select a start page and save to generate menu items.</p>
             <% end %>
-          <% else %>
-            <p class="text-sm text-gray-500 dark:text-gray-400">No menu items generated yet. Select a start page and save to generate menu items.</p>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/panda/cms/admin/menus/new.html.erb
+++ b/app/views/panda/cms/admin/menus/new.html.erb
@@ -1,10 +1,3 @@
-<%= render Panda::Core::Admin::BreadcrumbComponent.new(
-  items: [
-    { text: "Menus", href: admin_cms_menus_path },
-    { text: "New Menu", href: new_admin_cms_menu_path }
-  ]
-) %>
-
 <%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
   <% component.with_heading(text: "New Menu", level: 1) %>
 
@@ -21,22 +14,23 @@
     <div data-menu-form-target="menuItemsSection">
         <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
           <% panel.with_heading_slot(text: "Menu Items") %>
+          <% panel.with_body do %>
+            <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
+              <template data-nested-form-target="template">
+                <%= f.fields_for :menu_items, Panda::CMS::MenuItem.new, child_index: "NEW_RECORD" do |item_form| %>
+                  <%= render "menu_item_fields", form: item_form %>
+                <% end %>
+              </template>
 
-          <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
-            <template data-nested-form-target="template">
-              <%= f.fields_for :menu_items, Panda::CMS::MenuItem.new, child_index: "NEW_RECORD" do |item_form| %>
-                <%= render "menu_item_fields", form: item_form %>
-              <% end %>
-            </template>
+              <div class="space-y-4"></div>
 
-            <div class="space-y-4"></div>
+              <div data-nested-form-target="target"></div>
 
-            <div data-nested-form-target="target"></div>
-
-            <div class="mt-4">
-              <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Menu Item", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>
+              <div class="mt-4">
+                <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Menu Item", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>
+              </div>
             </div>
-          </div>
+          <% end %>
         <% end %>
       </div>
 

--- a/app/views/panda/cms/admin/pages/new.html.erb
+++ b/app/views/panda/cms/admin/pages/new.html.erb
@@ -1,10 +1,3 @@
-<%= render Panda::Core::Admin::BreadcrumbComponent.new(
-  items: [
-    { text: "Pages", href: admin_cms_pages_path },
-    { text: "New Page", href: new_admin_cms_page_path }
-  ]
-) %>
-
 <%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
   <% component.with_heading(text: "Add Page", level: 1) %>
 

--- a/app/views/panda/cms/admin/posts/edit.html.erb
+++ b/app/views/panda/cms/admin/posts/edit.html.erb
@@ -1,10 +1,3 @@
-<%= render Panda::Core::Admin::BreadcrumbComponent.new(
-  items: [
-    { text: "Posts", href: admin_cms_posts_path },
-    { text: "Edit Post", href: edit_admin_cms_post_path(post.admin_param) }
-  ]
-) %>
-
 <%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
   <% component.with_heading(text: post.title, level: 1) do |heading| %>
     <% heading.with_button(action: :view, text: "View Post", href: post_path(post.admin_param)) %>

--- a/app/views/panda/cms/admin/posts/new.html.erb
+++ b/app/views/panda/cms/admin/posts/new.html.erb
@@ -1,10 +1,3 @@
-<%= render Panda::Core::Admin::BreadcrumbComponent.new(
-  items: [
-    { text: "Posts", href: admin_cms_posts_path },
-    { text: "New Post", href: new_admin_cms_post_path }
-  ]
-) %>
-
 <%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
   <% component.with_heading(text: "Add Post", level: 1) do |heading| %>
   <% end %>

--- a/app/views/panda/cms/admin/settings/index.html.erb
+++ b/app/views/panda/cms/admin/settings/index.html.erb
@@ -3,17 +3,19 @@
 
   <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
     <% panel.with_heading_slot(text: "System Status") %>
-
-    <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Panda CMS:</span> v<%= Panda::CMS::VERSION %></p>
-    <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Rails:</span> v<%= Rails.version %></p>
-    <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Ruby:</span> v<%= RUBY_VERSION %></p>
-    <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Environment:</span> <%= Rails.env.titleize %></p>
+    <% panel.with_body do %>
+      <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Panda CMS:</span> v<%= Panda::CMS::VERSION %></p>
+      <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Rails:</span> v<%= Rails.version %></p>
+      <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Ruby:</span> v<%= RUBY_VERSION %></p>
+      <p class="text-base leading-loose"><i class="mr-2 text-active fa fa-check-circle"></i> <span class="font-medium">Environment:</span> <%= Rails.env.titleize %></p>
+    <% end %>
   <% end %>
 
   <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
     <% panel.with_heading_slot(text: "Integrations") %>
-
-    <p class="text-base leading-loose"><i class="mr-2 text-active fa-brands fa-instagram"></i> <span class="font-medium">Instagram:</span> <%= Panda::CMS.config.instagram[:enabled] ? "Connected (@#{Panda::CMS.config.instagram[:username]})" : "Not Connected" %></p>
+    <% panel.with_body do %>
+      <p class="text-base leading-loose"><i class="mr-2 text-active fa-brands fa-instagram"></i> <span class="font-medium">Instagram:</span> <%= Panda::CMS.config.instagram[:enabled] ? "Connected (@#{Panda::CMS.config.instagram[:username]})" : "Not Connected" %></p>
+    <% end %>
   <% end %>
 
   <div class="text-center mt-6 space-y-2">


### PR DESCRIPTION
## Summary
- Remove duplicate BreadcrumbComponent renders from templates (breadcrumbs are already added via controller and rendered in layout)
- Wrap panel content in `with_body` for proper rendering in:
  - settings/index.html.erb
  - forms/edit.html.erb (3 panels)
  - menus/new.html.erb
  - menus/edit.html.erb (2 panels)

## Pages Fixed
- Menus (new, edit) - duplicate breadcrumbs + panel content
- Pages (new) - duplicate breadcrumbs
- Posts (new, edit) - duplicate breadcrumbs  
- Forms (edit) - panel content
- Settings (index) - panel content

## Test plan
- [x] Component tests pass
- [ ] Verify on staging that:
  - Breadcrumbs no longer appear twice on menu/page/post pages
  - Settings page shows content inside panels
  - Forms edit page shows content inside panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)