### PR TITLE
Fix ViewComponent slot method name in PopularPagesComponent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 0be9406545b6ef161ccba8bb97c443cb96706113
+  revision: 687f9930f2b5f4f434388f6f8a6e3278a5a22d5f
   branch: main
   specs:
     panda-core (0.13.0)

--- a/app/components/panda/cms/admin/popular_pages_component.html.erb
+++ b/app/components/panda/cms/admin/popular_pages_component.html.erb
@@ -1,7 +1,7 @@
 <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
   <% panel.with_heading_slot(text: "Popular Pages (#{period_name})") %>
 
-  <% panel.body do %>
+  <% panel.with_body_slot do %>
     <% if popular_pages.any? %>
       <div class="overflow-y-auto max-h-96">
         <table class="min-w-full divide-y divide-gray-300">


### PR DESCRIPTION
## Summary
- Fix slot method call in PopularPagesComponent to match ViewComponent's naming convention
- Change `panel.body do` → `panel.with_body_slot do`

## Files Changed
- `app/components/panda/cms/admin/popular_pages_component.html.erb`

## Dependency
This PR depends on https://github.com/tastybamboo/panda-core/pull/71 being merged first.

## Test plan
- [ ] Verify Popular Pages component renders correctly on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)