### PR TITLE
Fix menu item validation error when removing items

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 3695b0c2e9bf2f8a92f90faae3435a43fbcc80a2
+  revision: 267aa622893f89e1c1a56d455902c8011581a869
   branch: main
   specs:
     panda-core (0.13.0)
@@ -433,8 +433,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.10.2)
+    rbs (3.10.3)
       logger
+      tsort
     rdoc (7.1.0)
       erb
       psych (>= 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 8b770b93f6b051406dfd9361c6a7743eeb09343f
+  revision: 3695b0c2e9bf2f8a92f90faae3435a43fbcc80a2
   branch: main
   specs:
     panda-core (0.13.0)
@@ -130,7 +130,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
-    annotaterb (4.20.0)
+    annotaterb (4.21.0)
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     ast (2.4.3)
@@ -153,7 +153,7 @@ GEM
     bigdecimal (4.0.1)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
-    brakeman (7.1.2)
+    brakeman (8.0.1)
       racc
     builder (3.3.0)
     bullet (8.1.0)
@@ -466,7 +466,7 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.6)
+    rspec-support (3.13.7)
     rubocop (1.82.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -568,7 +568,7 @@ GEM
     thor (1.5.0)
     timeout (0.6.0)
     tsort (0.2.0)
-    turbo-rails (2.0.21)
+    turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
     tzinfo (2.0.6)

--- a/app/models/panda/cms/menu_item.rb
+++ b/app/models/panda/cms/menu_item.rb
@@ -16,10 +16,10 @@ module Panda
         optional: true
 
       validates :text, presence: true, uniqueness: {scope: :panda_cms_menu_id, case_sensitive: false}
-      validates :page, presence: true, unless: -> { external_url.present? }
-      validates :external_url, presence: true, unless: -> { page.present? }
+      validates :page, presence: true, unless: -> { marked_for_destruction? || external_url.present? }
+      validates :external_url, presence: true, unless: -> { marked_for_destruction? || page.present? }
 
-      validate :validate_is_actual_link
+      validate :validate_is_actual_link, unless: :marked_for_destruction?
 
       #
       # Returns the resolved link for the menu item.

--- a/spec/models/panda/cms/menu_item_spec.rb
+++ b/spec/models/panda/cms/menu_item_spec.rb
@@ -111,6 +111,30 @@ RSpec.describe Panda::CMS::MenuItem, type: :model do
         expect(menu_item.errors[:external_url]).to include("must be a valid page or external link, neither are set")
       end
     end
+
+    context "when marked for destruction" do
+      it "skips link validations" do
+        menu_item = Panda::CMS::MenuItem.new(
+          text: "Doomed Item",
+          menu: main_menu,
+          page: nil,
+          external_url: nil
+        )
+        menu_item.mark_for_destruction
+        expect(menu_item).to be_valid
+      end
+
+      it "skips the both-set validation" do
+        menu_item = Panda::CMS::MenuItem.new(
+          text: "Doomed Item",
+          menu: main_menu,
+          page: homepage,
+          external_url: "https://example.com"
+        )
+        menu_item.mark_for_destruction
+        expect(menu_item).to be_valid
+      end
+    end
   end
 
   describe "nested set behavior" do

--- a/spec/models/panda/cms/menu_spec.rb
+++ b/spec/models/panda/cms/menu_spec.rb
@@ -212,6 +212,44 @@ RSpec.describe Panda::CMS::Menu, type: :model do
     end
   end
 
+  describe "nested attributes" do
+    it "allows removing menu items via _destroy" do
+      menu = static_menu
+      item = menu.menu_items.first
+
+      expect {
+        menu.update!(menu_items_attributes: [{id: item.id, _destroy: "1"}])
+      }.to change { menu.menu_items.count }.by(-1)
+    end
+
+    it "allows removing multiple menu items at once" do
+      menu = static_menu
+      items = menu.menu_items.to_a
+
+      attrs = items.map { |item| {id: item.id, _destroy: "1"} }
+
+      expect {
+        menu.update!(menu_items_attributes: attrs)
+      }.to change { menu.menu_items.count }.by(-items.size)
+    end
+
+    it "allows removing some items while keeping others" do
+      menu = static_menu
+      keep_item = panda_cms_menu_items(:home_link)
+      remove_item = panda_cms_menu_items(:about_link)
+
+      expect {
+        menu.update!(menu_items_attributes: [
+          {id: keep_item.id, text: keep_item.text},
+          {id: remove_item.id, _destroy: "1"}
+        ])
+      }.to change { menu.menu_items.count }.by(-1)
+
+      expect(menu.menu_items.reload).to include(keep_item)
+      expect(menu.menu_items.reload).not_to include(remove_item)
+    end
+  end
+
   describe "fixture data integrity" do
     it "loads static menu correctly" do
       expect(static_menu.name).to eq("Main Menu")


### PR DESCRIPTION
## Summary
- Skip page/external_url validations on menu items marked for destruction via nested attributes
- Fixes admin menu editor showing "must be a valid page or external link, both are set" errors when removing menu items and saving

## Root cause
Rails' `accepts_nested_attributes_for` with `allow_destroy: true` still runs validations on records marked for destruction. When a user clicks "Remove" on a menu item, the JS sets `_destroy: 1` but the form fields still contain values, triggering the mutual-exclusivity validation.

## Fix
Added `marked_for_destruction?` checks to all three link-related validations in `MenuItem`:
- `validates :page` — skip when marked for destruction
- `validates :external_url` — skip when marked for destruction  
- `validate :validate_is_actual_link` — skip when marked for destruction

## Test plan
- [x] MenuItem model spec: items marked for destruction skip link validations
- [x] MenuItem model spec: items marked for destruction skip both-set validation
- [x] Menu model spec: removing items via `_destroy` nested attributes succeeds
- [x] Menu model spec: removing multiple items at once succeeds
- [x] Menu model spec: removing some items while keeping others succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)