### PR TITLE
Add file management: delete, dedup, cleanup

### DIFF
--- a/app/controllers/panda/cms/admin/files_controller.rb
+++ b/app/controllers/panda/cms/admin/files_controller.rb
@@ -31,8 +31,13 @@ module Panda
 
         def destroy
           blob = ActiveStorage::Blob.find(params[:id])
-          blob.purge
-          redirect_to admin_cms_files_path, notice: "File was successfully deleted.", status: :see_other
+
+          if blob.attachments.exists?
+            redirect_to admin_cms_files_path, alert: "File cannot be deleted because it is still in use.", status: :see_other
+          else
+            blob.purge
+            redirect_to admin_cms_files_path, notice: "File was successfully deleted.", status: :see_other
+          end
         end
 
         private

--- a/app/controllers/panda/cms/admin/files_controller.rb
+++ b/app/controllers/panda/cms/admin/files_controller.rb
@@ -13,7 +13,7 @@ module Panda
           file = params[:image]
           return render json: {success: 0} unless file
 
-          blob = ActiveStorage::Blob.create_and_upload!(
+          blob = find_existing_blob(file) || ActiveStorage::Blob.create_and_upload!(
             io: file,
             filename: file.original_filename,
             content_type: file.content_type
@@ -29,7 +29,18 @@ module Panda
           }
         end
 
+        def destroy
+          blob = ActiveStorage::Blob.find(params[:id])
+          blob.purge
+          redirect_to admin_cms_files_path, notice: "File was successfully deleted.", status: :see_other
+        end
+
         private
+
+        def find_existing_blob(file)
+          checksum = Digest::MD5.file(file.tempfile.path).base64digest
+          ActiveStorage::Blob.find_by(checksum: checksum, byte_size: file.size)
+        end
       end
     end
   end

--- a/app/javascript/panda/cms/controllers/file_gallery_controller.js
+++ b/app/javascript/panda/cms/controllers/file_gallery_controller.js
@@ -77,7 +77,10 @@ export default class extends Controller {
       <div>
         <div class="block overflow-hidden w-full rounded-lg aspect-h-7 aspect-w-10">
           ${isImage ?
-            `<img src="${fileData.url}" alt="${fileData.name}" class="object-cover" onerror="this.onerror=null;this.parentNode.innerHTML='<div class=\\'flex items-center justify-center h-full bg-gray-100\\'><i class=\\'fa-solid fa-file-image text-4xl text-gray-400\\'></i></div>'">` :
+            `<img src="${fileData.url}" alt="${fileData.name}" class="object-cover" onerror="this.onerror=null;this.style.display='none';this.nextElementSibling.classList.remove('hidden')">
+            <div class="hidden flex items-center justify-center h-full bg-gray-100" role="img" aria-label="Image preview not available">
+              <i class="fa-solid fa-file-image text-4xl text-gray-400"></i>
+            </div>` :
             `<div class="flex items-center justify-center h-full bg-gray-100">
               <div class="text-center">
                 <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/javascript/panda/cms/controllers/file_gallery_controller.js
+++ b/app/javascript/panda/cms/controllers/file_gallery_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["slideoverContent"]
+  static values = { filesPath: String }
 
   selectFile(event) {
     const button = event.currentTarget
@@ -76,7 +77,7 @@ export default class extends Controller {
       <div>
         <div class="block overflow-hidden w-full rounded-lg aspect-h-7 aspect-w-10">
           ${isImage ?
-            `<img src="${fileData.url}" alt="${fileData.name}" class="object-cover">` :
+            `<img src="${fileData.url}" alt="${fileData.name}" class="object-cover" onerror="this.onerror=null;this.parentNode.innerHTML='<div class=\\'flex items-center justify-center h-full bg-gray-100\\'><i class=\\'fa-solid fa-file-image text-4xl text-gray-400\\'></i></div>'">` :
             `<div class="flex items-center justify-center h-full bg-gray-100">
               <div class="text-center">
                 <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -113,9 +114,18 @@ export default class extends Controller {
 
       <div class="flex gap-x-3">
         <a href="${fileData.url}?disposition=attachment" class="flex-1 py-2 px-3 text-sm font-semibold text-white bg-black rounded-md shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-panda-dark text-center">Download</a>
-        <button type="button" class="flex-1 py-2 px-3 text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset shadow-sm hover:bg-gray-50 ring-mid">Delete</button>
+        <form action="${this.filesPathValue}/${fileData.id}" method="post" class="flex-1" data-turbo-confirm="Are you sure you want to delete this file?">
+          <input type="hidden" name="_method" value="delete">
+          <input type="hidden" name="authenticity_token" value="${this.csrfToken}">
+          <button type="submit" class="w-full py-2 px-3 text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset shadow-sm hover:bg-gray-50 ring-mid">Delete</button>
+        </form>
       </div>
     `
+  }
+
+  get csrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]')
+    return meta ? meta.getAttribute("content") : ""
   }
 
   humanFileSize(bytes) {

--- a/app/views/panda/cms/admin/files/_file_details.html.erb
+++ b/app/views/panda/cms/admin/files/_file_details.html.erb
@@ -1,7 +1,10 @@
 <div>
   <div class="block overflow-hidden w-full rounded-lg aspect-h-7 aspect-w-10">
     <% if file.image? %>
-      <%= image_tag main_app.rails_blob_path(file, only_path: true), alt: file.filename.to_s, class: "object-cover", onerror: "this.onerror=null;this.parentNode.innerHTML='<div class=\"flex items-center justify-center h-full bg-gray-100\"><i class=\"fa-solid fa-file-image text-4xl text-gray-400\"></i></div>'" %>
+      <%= image_tag main_app.rails_blob_path(file, only_path: true), alt: file.filename.to_s, class: "object-cover", onerror: "this.onerror=null;this.style.display='none';this.nextElementSibling.classList.remove('hidden')" %>
+      <div class="hidden flex items-center justify-center h-full bg-gray-100" role="img" aria-label="Image preview not available">
+        <i class="fa-solid fa-file-image text-4xl text-gray-400"></i>
+      </div>
     <% else %>
       <div class="flex items-center justify-center h-full bg-gray-100">
         <div class="text-center">

--- a/app/views/panda/cms/admin/files/_file_details.html.erb
+++ b/app/views/panda/cms/admin/files/_file_details.html.erb
@@ -1,7 +1,7 @@
 <div>
   <div class="block overflow-hidden w-full rounded-lg aspect-h-7 aspect-w-10">
     <% if file.image? %>
-      <%= image_tag main_app.rails_blob_path(file, only_path: true), alt: file.filename.to_s, class: "object-cover" %>
+      <%= image_tag main_app.rails_blob_path(file, only_path: true), alt: file.filename.to_s, class: "object-cover", onerror: "this.onerror=null;this.parentNode.innerHTML='<div class=\"flex items-center justify-center h-full bg-gray-100\"><i class=\"fa-solid fa-file-image text-4xl text-gray-400\"></i></div>'" %>
     <% else %>
       <div class="flex items-center justify-center h-full bg-gray-100">
         <div class="text-center">
@@ -41,5 +41,7 @@
 
 <div class="flex gap-x-3">
   <%= link_to "Download", main_app.rails_blob_path(file, disposition: "attachment"), class: "flex-1 py-2 px-3 text-sm font-semibold text-white bg-black rounded-md shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-panda-dark text-center" %>
-  <%= button_tag "Delete", type: "button", class: "flex-1 py-2 px-3 text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset shadow-sm hover:bg-gray-50 ring-mid", data: { confirm: "Are you sure you want to delete this file?" } %>
+  <%= button_to "Delete", admin_cms_file_path(file), method: :delete, class: "flex-1", form: { data: { turbo_confirm: "Are you sure you want to delete this file?" } } do %>
+    <span class="block w-full py-2 px-3 text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset shadow-sm hover:bg-gray-50 ring-mid text-center">Delete</span>
+  <% end %>
 </div>

--- a/app/views/panda/cms/admin/files/index.html.erb
+++ b/app/views/panda/cms/admin/files/index.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <div data-controller="file-gallery" class="pb-24">
+  <div data-controller="file-gallery" data-file-gallery-files-path-value="<%= admin_cms_files_path %>" class="pb-24">
     <%= render Panda::Core::Admin::FileGalleryComponent.new(files: @files, selected_file: @selected_file) %>
   </div>
 <% end %>

--- a/lib/tasks/panda/cms/files.rake
+++ b/lib/tasks/panda/cms/files.rake
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+namespace :panda do
+  namespace :cms do
+    namespace :files do
+      desc "Purge ALL ActiveStorage data (blobs, attachments, variants) and clear image block references"
+      task purge_all: [:environment] do
+        unless ENV["CONFIRM"] == "yes"
+          puts "This will permanently delete ALL uploaded files."
+          puts "Run with CONFIRM=yes to proceed."
+          exit 1
+        end
+
+        variant_count = ActiveStorage::VariantRecord.count
+        ActiveStorage::VariantRecord.delete_all
+        puts "Deleted #{variant_count} variant records"
+
+        attachment_count = ActiveStorage::Attachment.count
+        ActiveStorage::Attachment.delete_all
+        puts "Deleted #{attachment_count} attachment records"
+
+        blob_count = ActiveStorage::Blob.count
+        ActiveStorage::Blob.find_each do |blob|
+          blob.purge
+        end
+        puts "Purged #{blob_count} blobs (and their backing files)"
+
+        image_blocks = Panda::CMS::Block.where(kind: :image)
+        block_content_count = Panda::CMS::BlockContent
+          .where(panda_cms_block_id: image_blocks.select(:id))
+          .update_all(content: nil, cached_content: nil)
+        puts "Cleared #{block_content_count} image block content references"
+
+        puts "Done."
+      end
+
+      desc "Find and optionally purge orphaned blobs (no attachments). Run with CONFIRM=yes to purge."
+      task cleanup_orphaned: [:environment] do
+        orphaned = ActiveStorage::Blob.left_joins(:attachments)
+          .where(active_storage_attachments: {id: nil})
+
+        if orphaned.none?
+          puts "No orphaned blobs found."
+          next
+        end
+
+        puts "Found #{orphaned.count} orphaned blobs:"
+        orphaned.find_each do |blob|
+          puts "  #{blob.filename} (#{blob.byte_size} bytes, created #{blob.created_at.to_date})"
+        end
+
+        if ENV["CONFIRM"] == "yes"
+          count = 0
+          orphaned.find_each do |blob|
+            blob.purge
+            count += 1
+          end
+          puts "Purged #{count} orphaned blobs."
+        else
+          puts "\nRun with CONFIRM=yes to purge these blobs."
+        end
+      end
+
+      desc "Find and optionally purge duplicate blobs (same checksum). Keeps oldest. Run with CONFIRM=yes to purge."
+      task cleanup_duplicates: [:environment] do
+        duplicate_checksums = ActiveStorage::Blob
+          .group(:checksum)
+          .having("COUNT(*) > 1")
+          .pluck(:checksum)
+
+        if duplicate_checksums.empty?
+          puts "No duplicate blobs found."
+          next
+        end
+
+        total_duplicates = 0
+        duplicate_checksums.each do |checksum|
+          blobs = ActiveStorage::Blob.where(checksum: checksum).order(created_at: :asc)
+          keeper = blobs.first
+          duplicates = blobs.offset(1)
+
+          puts "Checksum #{checksum}:"
+          puts "  Keeping: #{keeper.filename} (id: #{keeper.id}, created #{keeper.created_at.to_date})"
+          duplicates.each do |blob|
+            puts "  Duplicate: #{blob.filename} (id: #{blob.id}, created #{blob.created_at.to_date})"
+            total_duplicates += 1
+          end
+        end
+
+        if ENV["CONFIRM"] == "yes"
+          purged = 0
+          duplicate_checksums.each do |checksum|
+            blobs = ActiveStorage::Blob.where(checksum: checksum).order(created_at: :asc)
+            blobs.offset(1).find_each do |blob|
+              blob.purge
+              purged += 1
+            end
+          end
+          puts "Purged #{purged} duplicate blobs."
+        else
+          puts "\nFound #{total_duplicates} duplicate blobs across #{duplicate_checksums.size} checksums."
+          puts "Run with CONFIRM=yes to purge duplicates (keeping the oldest of each)."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Delete button works**: Added `destroy` action to files controller; fixed the Delete button in both the server-rendered partial (`button_to` with Turbo confirm) and the JS-rendered slideover (proper form with `_method=delete` and CSRF token)
- **Upload deduplication**: `create` action now computes the file's MD5 checksum and checks for an existing blob before uploading, preventing duplicate storage
- **Rake tasks** (`panda:cms:files:purge_all`, `cleanup_orphaned`, `cleanup_duplicates`): All require `CONFIRM=yes` safety gate. Purge all clears everything including image block references. Orphaned/duplicate tasks support dry-run by default.
- **Broken image fallback**: Added `onerror` handlers on `<img>` tags in the file detail panel (server + JS rendered) to show a clean icon when images 404
- **Configurable admin path**: JS delete form uses a Stimulus value for the files path instead of hardcoding `/admin/cms/files`

## Test plan
- [ ] Test Delete button removes a file and redirects back to the file index
- [ ] Upload the same file twice — verify no duplicate blob is created
- [ ] Run `bin/rails panda:cms:files:cleanup_orphaned` (dry-run) and with `CONFIRM=yes`
- [ ] Run `bin/rails panda:cms:files:cleanup_duplicates` (dry-run)
- [ ] Run `bin/rails panda:cms:files:purge_all CONFIRM=yes` on test data
- [ ] Verify broken images show a clean placeholder in the detail panel
- [ ] Run `bundle exec rspec` — all 412 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)