### PR TITLE
Add signature field type

### DIFF
--- a/app/controllers/panda/cms/admin/forms_controller.rb
+++ b/app/controllers/panda/cms/admin/forms_controller.rb
@@ -22,10 +22,11 @@ module Panda
           submissions = @form.form_submissions.order(created_at: :desc)
 
           # Use form field definitions if available, otherwise infer from submissions
+          # Fields are triples: [name, label, field_type]
           fields = if @form.form_fields.any?
-            @form.form_fields.active.ordered.map { |f| [f.name, f.label] }
+            @form.form_fields.active.ordered.map { |f| [f.name, f.label, f.field_type] }
           elsif submissions.any?
-            submissions.last.data.keys.reverse.map { |field| [field, field.titleize] }
+            submissions.last.data.keys.reverse.map { |field| [field, field.titleize, "text"] }
           else
             []
           end

--- a/app/helpers/panda/cms/forms_helper.rb
+++ b/app/helpers/panda/cms/forms_helper.rb
@@ -167,6 +167,8 @@ module Panda
           file_field_tag(field.name,
             required: field.required,
             class: "block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200")
+        when "signature"
+          content_tag(:p, "Signature fields are not available for web form input.", class: "text-sm text-gray-500 italic")
         when "hidden"
           hidden_field_tag(field.name, field.placeholder)
         when "date"

--- a/app/models/panda/cms/form_field.rb
+++ b/app/models/panda/cms/form_field.rb
@@ -3,7 +3,7 @@
 module Panda
   module CMS
     class FormField < ApplicationRecord
-      FIELD_TYPES = %w[text email phone url textarea select checkbox radio file hidden date number].freeze
+      FIELD_TYPES = %w[text email phone url textarea select checkbox radio file hidden date number signature].freeze
 
       self.table_name = "panda_cms_form_fields"
 
@@ -52,6 +52,12 @@ module Panda
       # @return [Boolean]
       def file_upload?
         field_type == "file"
+      end
+
+      # Check if field contains a signature
+      # @return [Boolean]
+      def signature?
+        field_type == "signature"
       end
 
       # Check if field has multiple options (select, radio, checkbox)

--- a/app/views/panda/cms/admin/forms/show.html.erb
+++ b/app/views/panda/cms/admin/forms/show.html.erb
@@ -4,12 +4,15 @@
   <% end %>
 
   <%= render Panda::Core::Admin::TableComponent.new(term: "submission", rows: submissions) do |table| %>
-    <% fields.each do |field, title| %>
+    <% fields.each do |field, title, field_type| %>
       <% table.column(title) do |submission| %>
-        <% if field == "email" || field == "email_address" %>
-          <a href="mailto:<%= submission.data[field] %>" class="border-b border-gray-500 hover:text-gray-900"><%= submission.data[field] %></a>
+        <% value = submission.data[field] %>
+        <% if field_type == "signature" && value.present? && value.start_with?("data:image") %>
+          <img src="<%= value %>" alt="Signature" style="max-width: 200px; max-height: 80px; border: 1px solid #e5e7eb;">
+        <% elsif field == "email" || field == "email_address" %>
+          <a href="mailto:<%= value %>" class="border-b border-gray-500 hover:text-gray-900"><%= value %></a>
         <% else %>
-          <%= simple_format(submission.data[field]) %>
+          <%= simple_format(value) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/panda/cms/form_mailer/notification_email.html.erb
+++ b/app/views/panda/cms/form_mailer/notification_email.html.erb
@@ -35,6 +35,8 @@
                   <a href="mailto:<%= value %>"><%= value %></a>
                 <% elsif field.field_type == "url" %>
                   <a href="<%= value %>"><%= value %></a>
+                <% elsif field.field_type == "signature" && value.start_with?("data:image") %>
+                  <img src="<%= value %>" alt="Signature" style="max-width: 300px; max-height: 100px; border: 1px solid #e5e7eb;">
                 <% elsif field.field_type == "textarea" %>
                   <%= simple_format(value) %>
                 <% elsif value.is_a?(Array) %>

--- a/spec/helpers/panda/cms/forms_helper_spec.rb
+++ b/spec/helpers/panda/cms/forms_helper_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe Panda::CMS::FormsHelper, type: :helper do
       expect(html).to include("</textarea>")
     end
 
+    it "renders signature field with informational message" do
+      field = form.form_fields.create!(
+        name: "signature",
+        label: "Signature",
+        field_type: "signature"
+      )
+
+      html = helper.send(:render_field_input, field)
+
+      expect(html).to include("Signature fields are not available for web form input.")
+      expect(html).to include("<p")
+    end
+
     it "renders select with options" do
       field = form.form_fields.create!(
         name: "country",

--- a/spec/models/panda/cms/form_field_spec.rb
+++ b/spec/models/panda/cms/form_field_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Panda::CMS::FormField, type: :model do
 
   describe "constants" do
     it "defines FIELD_TYPES with supported field types" do
-      expect(described_class::FIELD_TYPES).to eq(%w[text email phone url textarea select checkbox radio file hidden date number])
+      expect(described_class::FIELD_TYPES).to eq(%w[text email phone url textarea select checkbox radio file hidden date number signature])
     end
   end
 
@@ -192,6 +192,20 @@ RSpec.describe Panda::CMS::FormField, type: :model do
     end
   end
 
+  describe "#signature?" do
+    it "returns true for signature field type" do
+      field = described_class.new(form: form, name: "test", label: "Test", field_type: "signature")
+      expect(field.signature?).to be true
+    end
+
+    it "returns false for other field types" do
+      %w[text email phone textarea select file].each do |type|
+        field = described_class.new(form: form, name: "test", label: "Test", field_type: type)
+        expect(field.signature?).to be false
+      end
+    end
+  end
+
   describe "#has_options?" do
     it "returns true for select field type" do
       field = described_class.new(form: form, name: "test", label: "Test", field_type: "select")
@@ -209,7 +223,7 @@ RSpec.describe Panda::CMS::FormField, type: :model do
     end
 
     it "returns false for other field types" do
-      %w[text email phone textarea file hidden date number].each do |type|
+      %w[text email phone textarea file hidden date number signature].each do |type|
         field = described_class.new(form: form, name: "test", label: "Test", field_type: type)
         expect(field.has_options?).to be false
       end


### PR DESCRIPTION
## Summary
- Adds `"signature"` to `FIELD_TYPES` in `FormField` model with `signature?` convenience method
- Passes `field_type` through controller as a triple (`[name, label, field_type]`) to the admin submissions view
- Renders base64 data URI signatures as `<img>` tags in the admin table and notification emails
- Adds informational message for signature fields in frontend form rendering (signatures aren't user-fillable)
- Updates specs for the new field type

## Test plan
- [x] `bundle exec rspec spec/models/panda/cms/form_field_spec.rb` — 48 examples, 0 failures
- [x] `bundle exec rspec spec/helpers/panda/cms/forms_helper_spec.rb` — 10 examples, 0 failures
- [x] Brakeman security scan — no warnings
- [x] StandardRB — no offenses
- [x] ERB lint — no errors
- [ ] Verify on staging: admin → Forms → Trustee Declaration shows signatures as images after data migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)