### PR TITLE
Add canvas-based signature pad to frontend forms

### DIFF
--- a/app/helpers/panda/cms/forms_helper.rb
+++ b/app/helpers/panda/cms/forms_helper.rb
@@ -168,7 +168,7 @@ module Panda
             required: field.required,
             class: "block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200")
         when "signature"
-          content_tag(:p, "Signature fields are not available for web form input.", class: "text-sm text-gray-500 italic")
+          render_signature_pad(field)
         when "hidden"
           hidden_field_tag(field.name, field.placeholder)
         when "date"
@@ -219,6 +219,35 @@ module Panda
                 content_tag(:span, label, class: "ml-2 text-sm text-gray-700")
             end
           end.join.html_safe
+        end
+      end
+
+      # Renders a canvas-based signature pad using the signature_pad library
+      # @param field [Panda::CMS::FormField] The signature field
+      # @return [String] HTML for the signature pad
+      def render_signature_pad(field)
+        controller_data = {
+          controller: "signature-pad",
+          signature_pad_required_value: field.required
+        }
+
+        content_tag(:div, data: controller_data) do
+          buffer = ActiveSupport::SafeBuffer.new
+
+          buffer << content_tag(:canvas, nil,
+            data: {signature_pad_target: "canvas"},
+            class: "w-full border border-gray-300 rounded-md cursor-crosshair",
+            style: "height: 200px; touch-action: none;")
+
+          buffer << hidden_field_tag(field.name, nil,
+            data: {signature_pad_target: "hiddenField"})
+
+          buffer << content_tag(:button, "Clear",
+            type: "button",
+            data: {action: "click->signature-pad#clear"},
+            class: "mt-2 text-sm text-gray-600 hover:text-gray-800 underline")
+
+          buffer
         end
       end
 

--- a/app/helpers/panda/cms/forms_helper.rb
+++ b/app/helpers/panda/cms/forms_helper.rb
@@ -237,7 +237,9 @@ module Panda
           buffer << content_tag(:canvas, nil,
             data: {signature_pad_target: "canvas"},
             class: "w-full border border-gray-300 rounded-md cursor-crosshair",
-            style: "height: 200px; touch-action: none;")
+            style: "height: 200px; touch-action: none;",
+            role: "application",
+            aria: {label: "#{field.label} drawing area"})
 
           buffer << hidden_field_tag(field.name, nil,
             data: {signature_pad_target: "hiddenField"})

--- a/app/javascript/panda/cms/controllers/index.js
+++ b/app/javascript/panda/cms/controllers/index.js
@@ -32,7 +32,8 @@ const cmsControllers = [
   ["nested-form", "/panda/cms/controllers/nested_form_controller.js"],
   ["menu-form", "/panda/cms/controllers/menu_form_controller.js"],
   ["editor-form", "/panda/cms/controllers/editor_form_controller.js"],
-  ["editor-iframe", "/panda/cms/controllers/editor_iframe_controller.js"]
+  ["editor-iframe", "/panda/cms/controllers/editor_iframe_controller.js"],
+  ["signature-pad", "/panda/cms/controllers/signature_pad_controller.js"]
 ]
 
 // Load all controllers with error handling

--- a/app/javascript/panda/cms/controllers/signature_pad_controller.js
+++ b/app/javascript/panda/cms/controllers/signature_pad_controller.js
@@ -1,0 +1,88 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["canvas", "hiddenField", "clearButton"]
+  static values = {
+    penColor: { type: String, default: "black" },
+    backgroundColor: { type: String, default: "rgb(255,255,255)" },
+    required: { type: Boolean, default: false }
+  }
+
+  async connect() {
+    try {
+      const { default: SignaturePad } = await import("https://esm.sh/signature_pad@5.0.4")
+
+      this.pad = new SignaturePad(this.canvasTarget, {
+        penColor: this.penColorValue,
+        backgroundColor: this.backgroundColorValue
+      })
+
+      this.resizeCanvas()
+
+      this.resizeObserver = new ResizeObserver(() => this.resizeCanvas())
+      this.resizeObserver.observe(this.canvasTarget.parentElement)
+
+      this.form = this.element.closest("form")
+      if (this.form) {
+        this.submitHandler = (event) => this.save(event)
+        this.form.addEventListener("submit", this.submitHandler)
+      }
+    } catch (error) {
+      console.error("[Panda CMS] Failed to load signature_pad library:", error.message)
+    }
+  }
+
+  disconnect() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect()
+    }
+
+    if (this.form && this.submitHandler) {
+      this.form.removeEventListener("submit", this.submitHandler)
+    }
+
+    if (this.pad) {
+      this.pad.off()
+    }
+  }
+
+  resizeCanvas() {
+    if (!this.pad) return
+
+    const canvas = this.canvasTarget
+    const ratio = Math.max(window.devicePixelRatio || 1, 1)
+    const width = canvas.offsetWidth
+    const height = canvas.offsetHeight
+
+    canvas.width = width * ratio
+    canvas.height = height * ratio
+    canvas.getContext("2d").scale(ratio, ratio)
+
+    this.pad.clear()
+  }
+
+  clear() {
+    if (!this.pad) return
+
+    this.pad.clear()
+    this.hiddenFieldTarget.value = ""
+    this.hiddenFieldTarget.setCustomValidity("")
+  }
+
+  save(event) {
+    if (!this.pad) return
+
+    if (this.pad.isEmpty()) {
+      if (this.requiredValue) {
+        this.hiddenFieldTarget.setCustomValidity("Please provide a signature")
+        this.hiddenFieldTarget.reportValidity()
+        event.preventDefault()
+        return
+      }
+      this.hiddenFieldTarget.value = ""
+    } else {
+      this.hiddenFieldTarget.setCustomValidity("")
+      this.hiddenFieldTarget.value = this.pad.toDataURL("image/png")
+    }
+  }
+}

--- a/app/javascript/panda/cms/controllers/signature_pad_controller.js
+++ b/app/javascript/panda/cms/controllers/signature_pad_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["canvas", "hiddenField", "clearButton"]
+  static targets = ["canvas", "hiddenField"]
   static values = {
     penColor: { type: String, default: "black" },
     backgroundColor: { type: String, default: "rgb(255,255,255)" },
@@ -29,6 +29,10 @@ export default class extends Controller {
       }
     } catch (error) {
       console.error("[Panda CMS] Failed to load signature_pad library:", error.message)
+      this.canvasTarget.insertAdjacentHTML("afterend",
+        '<p class="text-sm text-red-600 mt-1">Signature pad could not be loaded. Please reload the page.</p>'
+      )
+      this.canvasTarget.style.display = "none"
     }
   }
 
@@ -54,11 +58,17 @@ export default class extends Controller {
     const width = canvas.offsetWidth
     const height = canvas.offsetHeight
 
+    const data = this.pad.isEmpty() ? null : this.pad.toData()
+
     canvas.width = width * ratio
     canvas.height = height * ratio
     canvas.getContext("2d").scale(ratio, ratio)
 
-    this.pad.clear()
+    if (data) {
+      this.pad.fromData(data)
+    } else {
+      this.pad.clear()
+    }
   }
 
   clear() {

--- a/spec/helpers/panda/cms/forms_helper_spec.rb
+++ b/spec/helpers/panda/cms/forms_helper_spec.rb
@@ -89,17 +89,37 @@ RSpec.describe Panda::CMS::FormsHelper, type: :helper do
       expect(html).to include("</textarea>")
     end
 
-    it "renders signature field with informational message" do
+    it "renders signature field with canvas-based signature pad" do
       field = form.form_fields.create!(
         name: "signature",
         label: "Signature",
-        field_type: "signature"
+        field_type: "signature",
+        required: true
       )
 
       html = helper.send(:render_field_input, field)
 
-      expect(html).to include("Signature fields are not available for web form input.")
-      expect(html).to include("<p")
+      expect(html).to include("<canvas")
+      expect(html).to include('data-signature-pad-target="canvas"')
+      expect(html).to include('data-controller="signature-pad"')
+      expect(html).to include('name="signature"')
+      expect(html).to include('type="hidden"')
+      expect(html).to include("Clear")
+      expect(html).to include('data-signature-pad-required-value="true"')
+    end
+
+    it "renders signature field without required attribute when not required" do
+      field = form.form_fields.create!(
+        name: "consent_signature",
+        label: "Consent Signature",
+        field_type: "signature",
+        required: false
+      )
+
+      html = helper.send(:render_field_input, field)
+
+      expect(html).to include("<canvas")
+      expect(html).to include('data-signature-pad-required-value="false"')
     end
 
     it "renders select with options" do

--- a/spec/helpers/panda/cms/forms_helper_spec.rb
+++ b/spec/helpers/panda/cms/forms_helper_spec.rb
@@ -106,6 +106,8 @@ RSpec.describe Panda::CMS::FormsHelper, type: :helper do
       expect(html).to include('type="hidden"')
       expect(html).to include("Clear")
       expect(html).to include('data-signature-pad-required-value="true"')
+      expect(html).to include('role="application"')
+      expect(html).to include('aria-label="Signature drawing area"')
     end
 
     it "renders signature field without required attribute when not required" do


### PR DESCRIPTION
## Summary

- Replace placeholder "not available" message for signature fields with an interactive canvas-based signature pad
- New Stimulus controller (`signature_pad_controller.js`) dynamically loads the `signature_pad` library from esm.sh CDN
- Captures signatures as `data:image/png;base64,...` values in a hidden input for form submission
- Supports retina/high-DPI displays via `ResizeObserver` and `devicePixelRatio` scaling
- Handles touch devices natively (mouse + touch + stylus)
- Includes required field validation (blocks submission if signature is empty)
- "Clear" button to reset the signature

## Files Changed

- **New:** `app/javascript/panda/cms/controllers/signature_pad_controller.js` — Stimulus controller
- **Modified:** `app/javascript/panda/cms/controllers/index.js` — Register the new controller
- **Modified:** `app/helpers/panda/cms/forms_helper.rb` — Render canvas + hidden input + clear button
- **Modified:** `spec/helpers/panda/cms/forms_helper_spec.rb` — Updated tests for new output

## Test plan

- [x] `bundle exec rspec spec/helpers/panda/cms/forms_helper_spec.rb` — 11 examples, 0 failures
- [ ] Manual test: create a form with a signature field, render on a page, draw signature, submit
- [ ] Verify base64 data appears in form submission admin view
- [ ] Test on mobile/touch device
- [ ] Test required validation (submit with empty signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)