### PR TITLE
Add multi-provider analytics architecture with tracking support

### DIFF
--- a/app/helpers/panda/cms/analytics_helper.rb
+++ b/app/helpers/panda/cms/analytics_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    # Helper for rendering analytics tracking scripts from all configured providers.
+    #
+    # Include this helper in your layout's <head> to automatically inject tracking
+    # scripts from any configured analytics providers (Google Analytics, Plausible,
+    # Ahoy, etc.).
+    #
+    # @example In your application layout
+    #   <head>
+    #     <%= panda_analytics %>
+    #   </head>
+    #
+    module AnalyticsHelper
+      # Renders tracking scripts from all configured analytics providers.
+      #
+      # Iterates over every registered provider that supports tracking and is
+      # fully configured, collecting their script tags into a single safe buffer.
+      #
+      # @param options [Hash] Options passed through to each provider's tracking_script
+      # @return [ActiveSupport::SafeBuffer, nil] Combined script tags, or nil if none
+      def panda_analytics(**options)
+        scripts = Panda::CMS::Analytics.tracking_providers.filter_map do |provider|
+          provider.tracking_script(**options)
+        end
+        return nil if scripts.empty?
+        safe_join(scripts)
+      end
+    end
+  end
+end

--- a/lib/panda/cms/analytics/ahoy_provider.rb
+++ b/lib/panda/cms/analytics/ahoy_provider.rb
@@ -67,14 +67,14 @@ module Panda
           return 0 unless configured?
           scope = ::Ahoy::Visit.where("started_at >= ?", period.ago)
           scope.sum { |v| v.respond_to?(:events) ? v.events.count : 1 }
-        rescue StandardError
+        rescue
           fallback_provider.page_views(period: period)
         end
 
         def unique_visitors(period: 30.days)
           return 0 unless configured?
           ::Ahoy::Visit.where("started_at >= ?", period.ago).distinct.count(:visitor_token)
-        rescue StandardError
+        rescue
           fallback_provider.unique_visitors(period: period)
         end
 
@@ -90,7 +90,7 @@ module Panda
             .limit(limit)
             .count
             .map { |url, count| {path: url, title: url, views: count} }
-        rescue StandardError
+        rescue
           fallback_provider.top_pages(limit: limit, period: period)
         end
 
@@ -105,7 +105,7 @@ module Panda
             .order(Arel.sql("DATE_TRUNC('#{trunc}', started_at)"))
             .count
             .map { |date, count| {date: date.to_date, views: count} }
-        rescue StandardError
+        rescue
           fallback_provider.page_views_over_time(period: period, interval: interval)
         end
 
@@ -120,7 +120,7 @@ module Panda
             .limit(limit)
             .count
             .map { |domain, count| {source: domain, visits: count} }
-        rescue StandardError
+        rescue
           fallback_provider.top_referrers(limit: limit, period: period)
         end
 

--- a/lib/panda/cms/analytics/ahoy_provider.rb
+++ b/lib/panda/cms/analytics/ahoy_provider.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    module Analytics
+      # Analytics provider using Ahoy for visit and event tracking.
+      #
+      # When the ahoy_matey gem is installed, this provider queries Ahoy::Visit
+      # and Ahoy::Event for dashboard analytics data. It can also optionally
+      # inject the ahoy.js tracking script on public pages.
+      #
+      # This provider is auto-registered when Ahoy is detected and replaces
+      # LocalProvider as the default data source.
+      #
+      # @example Enable frontend tracking via admin settings
+      #   # In Panda::CMS.config.analytics[:ahoy]:
+      #   { enabled: true, tracking_enabled: true }
+      #
+      class AhoyProvider < Provider
+        def self.slug
+          :ahoy
+        end
+
+        def self.display_name
+          "Ahoy"
+        end
+
+        def self.icon
+          "fa-solid fa-anchor"
+        end
+
+        def self.has_settings_page?
+          false
+        end
+
+        def configured?
+          defined?(::Ahoy::Visit) ? true : false
+        end
+
+        # --- Frontend tracking ---
+
+        def supports_tracking?
+          true
+        end
+
+        def tracking_configured?
+          return false unless configured?
+          config[:enabled] == true && config[:tracking_enabled] == true
+        end
+
+        def tracking_script(**options)
+          return nil unless tracking_configured?
+
+          # rubocop:disable Rails/OutputSafety
+          <<~HTML.html_safe
+            <!-- Ahoy.js -->
+            <script src="/ahoy.js"></script>
+          HTML
+          # rubocop:enable Rails/OutputSafety
+        end
+
+        # --- Data API ---
+
+        def page_views(period: 30.days)
+          return 0 unless configured?
+          scope = ::Ahoy::Visit.where("started_at >= ?", period.ago)
+          scope.sum { |v| v.respond_to?(:events) ? v.events.count : 1 }
+        rescue
+          fallback_provider.page_views(period: period)
+        end
+
+        def unique_visitors(period: 30.days)
+          return 0 unless configured?
+          ::Ahoy::Visit.where("started_at >= ?", period.ago).distinct.count(:visitor_token)
+        rescue
+          fallback_provider.unique_visitors(period: period)
+        end
+
+        def top_pages(limit: 10, period: 30.days)
+          return [] unless configured?
+          return fallback_provider.top_pages(limit: limit, period: period) unless defined?(::Ahoy::Event)
+
+          ::Ahoy::Event
+            .where(name: "$view")
+            .where("time >= ?", period.ago)
+            .group("properties->>'url'")
+            .order(Arel.sql("count(*) DESC"))
+            .limit(limit)
+            .count
+            .map { |url, count| {path: url, title: url, views: count} }
+        rescue
+          fallback_provider.top_pages(limit: limit, period: period)
+        end
+
+        def page_views_over_time(period: 30.days, interval: :daily)
+          return [] unless configured?
+
+          trunc = case interval
+          when :weekly then "week"
+          when :monthly then "month"
+          else "day"
+          end
+
+          ::Ahoy::Visit
+            .where("started_at >= ?", period.ago)
+            .group(Arel.sql("DATE_TRUNC('#{trunc}', started_at)"))
+            .order(Arel.sql("DATE_TRUNC('#{trunc}', started_at)"))
+            .count
+            .map { |date, count| {date: date.to_date, views: count} }
+        rescue
+          fallback_provider.page_views_over_time(period: period, interval: interval)
+        end
+
+        def top_referrers(limit: 10, period: 30.days)
+          return [] unless configured?
+
+          ::Ahoy::Visit
+            .where("started_at >= ?", period.ago)
+            .where.not(referring_domain: [nil, ""])
+            .group(:referring_domain)
+            .order(Arel.sql("count(*) DESC"))
+            .limit(limit)
+            .count
+            .map { |domain, count| {source: domain, visits: count} }
+        rescue
+          fallback_provider.top_referrers(limit: limit, period: period)
+        end
+
+        def name
+          "Ahoy"
+        end
+
+        private
+
+        def fallback_provider
+          @fallback_provider ||= LocalProvider.new
+        end
+      end
+    end
+  end
+end

--- a/lib/panda/cms/engine.rb
+++ b/lib/panda/cms/engine.rb
@@ -43,6 +43,22 @@ module Panda
           root: Panda::CMS::Engine.root.join("public")
       end
 
+      # Auto-register AhoyProvider when the ahoy_matey gem is available.
+      # When detected, Ahoy replaces LocalProvider as the default data source.
+      initializer "panda.cms.ahoy_provider" do
+        config.after_initialize do
+          if defined?(::Ahoy::Visit)
+            Panda::CMS::Analytics.register_provider(:ahoy, Panda::CMS::Analytics::AhoyProvider)
+            # Set Ahoy as the default provider unless one has already been explicitly configured
+            unless Panda::CMS::Analytics.current_provider_name
+              Panda::CMS::Analytics.current_provider_name = :ahoy
+              Panda::CMS::Analytics.reset!
+            end
+            Rails.logger.info "[Panda CMS] Ahoy detected — registered AhoyProvider as default analytics provider"
+          end
+        end
+      end
+
       # Configure custom error pages in production-like environments
       # This enables Panda CMS's custom 404, 500, and other error pages
       initializer "panda.cms.custom_error_pages", after: :load_config_initializers do |app|

--- a/lib/panda/cms/engine/helper_config.rb
+++ b/lib/panda/cms/engine/helper_config.rb
@@ -12,6 +12,7 @@ module Panda
           config.to_prepare do
             ApplicationController.helper(::ApplicationHelper)
             ApplicationController.helper(Panda::CMS::AssetHelper)
+            ApplicationController.helper(Panda::CMS::AnalyticsHelper)
           end
         end
       end

--- a/spec/helpers/panda/cms/analytics_helper_spec.rb
+++ b/spec/helpers/panda/cms/analytics_helper_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::AnalyticsHelper, type: :helper do
+  before do
+    @original_providers = Panda::CMS::Analytics.providers.dup
+    Panda::CMS::Analytics.reset!
+  end
+
+  after do
+    Panda::CMS::Analytics.instance_variable_set(:@providers, @original_providers)
+    Panda::CMS::Analytics.reset!
+  end
+
+  describe "#panda_analytics" do
+    context "when no tracking providers are configured" do
+      it "returns nil" do
+        expect(helper.panda_analytics).to be_nil
+      end
+    end
+
+    context "when tracking providers are configured" do
+      let(:tracking_provider) do
+        Class.new(Panda::CMS::Analytics::Provider) do
+          def configured? = true
+          def supports_tracking? = true
+          def tracking_configured? = true
+
+          def tracking_script(**)
+            "<script>track();</script>".html_safe
+          end
+        end
+      end
+
+      before do
+        Panda::CMS::Analytics.register_provider(:test_tracking, tracking_provider)
+        allow(Panda::CMS.config).to receive(:analytics).and_return({test_tracking: {enabled: true}})
+        Panda::CMS::Analytics.reset!
+      end
+
+      it "returns the combined script tags" do
+        result = helper.panda_analytics
+        expect(result).to include("<script>track();</script>")
+        expect(result).to be_html_safe
+      end
+    end
+
+    context "with multiple tracking providers" do
+      let(:provider_a) do
+        Class.new(Panda::CMS::Analytics::Provider) do
+          def configured? = true
+          def supports_tracking? = true
+          def tracking_configured? = true
+          def tracking_script(**) = "<script>providerA();</script>".html_safe
+        end
+      end
+
+      let(:provider_b) do
+        Class.new(Panda::CMS::Analytics::Provider) do
+          def configured? = true
+          def supports_tracking? = true
+          def tracking_configured? = true
+          def tracking_script(**) = "<script>providerB();</script>".html_safe
+        end
+      end
+
+      before do
+        Panda::CMS::Analytics.register_provider(:provider_a, provider_a)
+        Panda::CMS::Analytics.register_provider(:provider_b, provider_b)
+        allow(Panda::CMS.config).to receive(:analytics).and_return({
+          provider_a: {enabled: true},
+          provider_b: {enabled: true}
+        })
+        Panda::CMS::Analytics.reset!
+      end
+
+      it "renders scripts from all providers" do
+        result = helper.panda_analytics
+        expect(result).to include("providerA()")
+        expect(result).to include("providerB()")
+      end
+    end
+
+    context "when options are passed through" do
+      let(:options_provider) do
+        Class.new(Panda::CMS::Analytics::Provider) do
+          def configured? = true
+          def supports_tracking? = true
+          def tracking_configured? = true
+
+          def tracking_script(**options)
+            "<script>track(#{options.to_json});</script>".html_safe
+          end
+        end
+      end
+
+      before do
+        Panda::CMS::Analytics.register_provider(:options_test, options_provider)
+        allow(Panda::CMS.config).to receive(:analytics).and_return({options_test: {enabled: true}})
+        Panda::CMS::Analytics.reset!
+      end
+
+      it "passes options to the provider" do
+        result = helper.panda_analytics(anonymize_ip: true)
+        expect(result).to include("anonymize_ip")
+      end
+    end
+  end
+end

--- a/spec/lib/panda/cms/analytics/ahoy_provider_spec.rb
+++ b/spec/lib/panda/cms/analytics/ahoy_provider_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::Analytics::AhoyProvider do
+  let(:provider) { described_class.new(config) }
+  let(:config) { {} }
+
+  describe "class metadata" do
+    it "has correct slug" do
+      expect(described_class.slug).to eq(:ahoy)
+    end
+
+    it "has correct display_name" do
+      expect(described_class.display_name).to eq("Ahoy")
+    end
+
+    it "has correct icon" do
+      expect(described_class.icon).to eq("fa-solid fa-anchor")
+    end
+
+    it "does not have a settings page" do
+      expect(described_class.has_settings_page?).to be false
+    end
+  end
+
+  describe "#configured?" do
+    context "when Ahoy::Visit is defined" do
+      before do
+        stub_const("Ahoy::Visit", Class.new)
+      end
+
+      it "returns true" do
+        expect(provider.configured?).to be true
+      end
+    end
+
+    context "when Ahoy is not available" do
+      before do
+        hide_const("Ahoy") if defined?(Ahoy)
+      end
+
+      it "returns false" do
+        expect(provider.configured?).to be false
+      end
+    end
+  end
+
+  describe "#supports_tracking?" do
+    it "returns true" do
+      expect(provider.supports_tracking?).to be true
+    end
+  end
+
+  describe "#tracking_configured?" do
+    context "when Ahoy is available and tracking is enabled" do
+      let(:config) { {enabled: true, tracking_enabled: true} }
+
+      before do
+        stub_const("Ahoy::Visit", Class.new)
+      end
+
+      it "returns true" do
+        expect(provider.tracking_configured?).to be true
+      end
+    end
+
+    context "when tracking is not enabled" do
+      let(:config) { {enabled: true, tracking_enabled: false} }
+
+      before do
+        stub_const("Ahoy::Visit", Class.new)
+      end
+
+      it "returns false" do
+        expect(provider.tracking_configured?).to be false
+      end
+    end
+
+    context "when Ahoy is not available" do
+      let(:config) { {enabled: true, tracking_enabled: true} }
+
+      before do
+        hide_const("Ahoy") if defined?(Ahoy)
+      end
+
+      it "returns false" do
+        expect(provider.tracking_configured?).to be false
+      end
+    end
+  end
+
+  describe "#tracking_script" do
+    context "when tracking is configured" do
+      let(:config) { {enabled: true, tracking_enabled: true} }
+
+      before do
+        stub_const("Ahoy::Visit", Class.new)
+      end
+
+      it "returns ahoy.js script tag" do
+        result = provider.tracking_script
+        expect(result).to include("ahoy.js")
+        expect(result).to be_html_safe
+      end
+    end
+
+    context "when tracking is not configured" do
+      it "returns nil" do
+        expect(provider.tracking_script).to be_nil
+      end
+    end
+  end
+
+  describe "#name" do
+    it "returns 'Ahoy'" do
+      expect(provider.name).to eq("Ahoy")
+    end
+  end
+end

--- a/spec/lib/panda/cms/analytics/provider_spec.rb
+++ b/spec/lib/panda/cms/analytics/provider_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::Analytics::Provider do
+  let(:provider) { described_class.new({test: true}) }
+
+  describe ".slug" do
+    it "derives from class name" do
+      expect(described_class.slug).to eq(:provider)
+    end
+  end
+
+  describe ".display_name" do
+    it "derives from class name" do
+      expect(described_class.display_name).to eq("Provider")
+    end
+  end
+
+  describe ".icon" do
+    it "returns default icon" do
+      expect(described_class.icon).to eq("fa-solid fa-chart-line")
+    end
+  end
+
+  describe ".has_settings_page?" do
+    it "returns false by default" do
+      expect(described_class.has_settings_page?).to be false
+    end
+  end
+
+  describe "#supports_tracking?" do
+    it "returns false by default" do
+      expect(provider.supports_tracking?).to be false
+    end
+  end
+
+  describe "#tracking_script" do
+    it "returns nil by default" do
+      expect(provider.tracking_script).to be_nil
+    end
+  end
+
+  describe "#tracking_configured?" do
+    it "returns false by default" do
+      expect(provider.tracking_configured?).to be false
+    end
+  end
+
+  describe "#name" do
+    it "delegates to display_name" do
+      expect(provider.name).to eq("Provider")
+    end
+  end
+
+  describe "#config" do
+    it "returns the configuration hash" do
+      expect(provider.config).to eq({test: true})
+    end
+  end
+
+  describe "subclass metadata" do
+    let(:custom_provider) do
+      Class.new(described_class) do
+        def self.name = "Panda::CMS::Analytics::CustomTestProvider"
+        def self.slug = :custom_test
+        def self.display_name = "Custom Test"
+        def self.icon = "fa-solid fa-flask"
+        def self.has_settings_page? = true
+      end
+    end
+
+    it "allows subclasses to override class methods" do
+      expect(custom_provider.slug).to eq(:custom_test)
+      expect(custom_provider.display_name).to eq("Custom Test")
+      expect(custom_provider.icon).to eq("fa-solid fa-flask")
+      expect(custom_provider.has_settings_page?).to be true
+    end
+  end
+end

--- a/spec/lib/panda/cms/analytics_spec.rb
+++ b/spec/lib/panda/cms/analytics_spec.rb
@@ -4,6 +4,12 @@ require "rails_helper"
 
 RSpec.describe Panda::CMS::Analytics do
   before do
+    @original_providers = described_class.providers.dup
+    described_class.reset!
+  end
+
+  after do
+    described_class.instance_variable_set(:@providers, @original_providers)
     described_class.reset!
   end
 
@@ -56,6 +62,66 @@ RSpec.describe Panda::CMS::Analytics do
 
       expect(described_class.current_provider_name).to eq(:local)
       expect(described_class.provider_config).to eq({test: true})
+    end
+  end
+
+  describe ".tracking_providers" do
+    it "returns empty by default (LocalProvider does not track)" do
+      expect(described_class.tracking_providers).to be_empty
+    end
+
+    it "returns providers that support tracking and are configured" do
+      tracking_provider = Class.new(Panda::CMS::Analytics::Provider) do
+        def configured? = true
+        def supports_tracking? = true
+        def tracking_configured? = true
+        def tracking_script(**) = "<script>test</script>".html_safe
+      end
+
+      described_class.register_provider(:test_tracking, tracking_provider)
+      allow(Panda::CMS.config).to receive(:analytics).and_return({test_tracking: {enabled: true}})
+      described_class.reset!
+
+      expect(described_class.tracking_providers).not_to be_empty
+      expect(described_class.tracking_providers.first).to be_a(tracking_provider)
+    end
+
+    it "excludes providers that support tracking but are not configured" do
+      unconfigured_provider = Class.new(Panda::CMS::Analytics::Provider) do
+        def configured? = false
+        def supports_tracking? = true
+        def tracking_configured? = false
+      end
+
+      described_class.register_provider(:unconfigured, unconfigured_provider)
+      described_class.reset!
+
+      tracking = described_class.tracking_providers.select { |p| p.is_a?(unconfigured_provider) }
+      expect(tracking).to be_empty
+    end
+
+    it "is cleared on reset!" do
+      described_class.tracking_providers # warm the cache
+      described_class.reset!
+      # After reset, should rebuild (still empty for default providers)
+      expect(described_class.tracking_providers).to be_empty
+    end
+  end
+
+  describe ".settings_providers" do
+    it "returns empty by default" do
+      expect(described_class.settings_providers).to be_empty
+    end
+
+    it "returns providers with settings pages" do
+      settings_provider = Class.new(Panda::CMS::Analytics::Provider) do
+        def self.has_settings_page? = true
+        def configured? = true
+      end
+
+      described_class.register_provider(:with_settings, settings_provider)
+
+      expect(described_class.settings_providers).to include(settings_provider)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Extend the analytics `Provider` base class with frontend tracking methods (`supports_tracking?`, `tracking_script`, `tracking_configured?`) and class-level metadata (`slug`, `display_name`, `icon`, `has_settings_page?`) for UI/navigation
- Add `panda_analytics` helper that renders tracking scripts from all configured providers via `safe_join`
- Add `AhoyProvider` that auto-registers when `ahoy_matey` is detected, providing both data API queries (visits, events, referrers) and optional `ahoy.js` script injection
- Add `tracking_providers` and `settings_providers` methods to the `Analytics` module for multi-provider support used by panda-cms-pro

## Test plan

- [x] Provider base class specs pass (slug, display_name, icon, has_settings_page?, tracking defaults)
- [x] AhoyProvider specs pass (configured?, tracking, class metadata)
- [x] AnalyticsHelper specs pass (nil when no providers, single provider, multiple providers, option passthrough)
- [x] Analytics module specs pass (tracking_providers, settings_providers, test isolation)
- [x] All 40 analytics specs pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)