### PR TITLE
Fix admin session key to match panda-core

### DIFF
--- a/app/controllers/panda/cms/application_controller.rb
+++ b/app/controllers/panda/cms/application_controller.rb
@@ -33,7 +33,7 @@ module Panda
         Panda::Core::Current.user_agent = request.user_agent
         Panda::Core::Current.ip_address = request.ip
         Panda::Core::Current.root = request.base_url
-        Panda::Core::Current.user ||= Panda::Core::User.find_by(id: session[:user_id]) if session[:user_id]
+        Panda::Core::Current.user ||= Panda::Core::User.find_by(id: session[Panda::Core::ADMIN_SESSION_KEY]) if session[Panda::Core::ADMIN_SESSION_KEY]
 
         # Set CMS current attributes (inherits from Core so has access to all Core attributes)
         Panda::CMS::Current.request_id = request.uuid


### PR DESCRIPTION
## Summary

- Fixes 500 errors on all `/manage` admin routes caused by a session key mismatch with panda-core

## Root Cause

panda-core renamed the admin session key from `:user_id` to `:panda_core_user_id` (via `Panda::Core::ADMIN_SESSION_KEY`), but panda-cms still used the old `session[:user_id]`. This caused `current_user` to always be `nil` in admin pages, resulting in 500 errors on every `/manage` route.

## Changes

One-line fix in `app/controllers/panda/cms/application_controller.rb` — use `Panda::Core::ADMIN_SESSION_KEY` instead of hardcoded `:user_id`.

## Test plan

- [x] Full panda-cms test suite: 800 examples, 0 failures
- [x] All pre-commit hooks pass (Brakeman, StandardRB, ERBLint, bundle-audit, zeitwerk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)