### PR TITLE
Delegate panda_cms_form_with to panda_form_with from core

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: a71e8f4d17b90af5af6e378f035878618361cdbe
+  revision: b0b006ae3faccadfdfb7bc39af59e6ad8a343cb6
   branch: main
   specs:
     panda-core (0.14.4)

--- a/app/helpers/panda/cms/application_helper.rb
+++ b/app/helpers/panda/cms/application_helper.rb
@@ -57,10 +57,10 @@ module Panda
         Panda::CMS::Features.enabled?(name)
       end
 
+      # Delegates to panda_form_with from Panda::Core::FormHelper.
+      # Kept for backwards compatibility with existing CMS views.
       def panda_cms_form_with(**options, &)
-        options[:builder] = Panda::Core::FormBuilder
-        options[:class] = ["block visible px-4 sm:px-6 pt-4", options[:class]].compact.join(" ")
-        form_with(**options, &)
+        panda_form_with(**options, &)
       end
 
       def nav_class(mode)


### PR DESCRIPTION
## Summary
- Delegates `panda_cms_form_with` to the new `panda_form_with` helper in `Panda::Core::FormHelper`
- The form styling logic (builder class + CSS padding classes) now lives in panda-core, so all engines (CMS, Helpdesk, CMS Pro, etc.) get consistent form styling
- `panda_cms_form_with` is kept as a thin wrapper for backwards compatibility with existing views

## Dependencies
- Requires tastybamboo/panda-core#86 to be merged first (adds `Panda::Core::FormHelper`)

## Test plan
- [ ] Verify existing CMS admin forms still render with correct padding/layout
- [ ] Verify form fields still use the custom `Panda::Core::FormBuilder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)