### PR TITLE
Add redirects admin UI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 1a0d5dbe2fe907381ca969e00db9b224bf22f189
+  revision: 9a7cd76d688b7aec3e4324ff96111bb0f72b717b
   branch: main
   specs:
     panda-core (0.14.4)

--- a/app/controllers/panda/cms/admin/redirects_controller.rb
+++ b/app/controllers/panda/cms/admin/redirects_controller.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    module Admin
+      class RedirectsController < ::Panda::CMS::Admin::BaseController
+        before_action :set_initial_breadcrumb
+        before_action :set_redirect, only: %i[edit update destroy]
+
+        # Lists all redirects
+        # @type GET
+        # @return ActiveRecord::Collection A list of all redirects
+        def index
+          redirects = Panda::CMS::Redirect.order(:origin_path)
+          render :index, locals: {redirects: redirects}
+        end
+
+        # New redirect
+        # @type GET
+        def new
+          redirect_record = Panda::CMS::Redirect.new(status_code: 301, visits: 0)
+          add_breadcrumb "New Redirect", new_admin_cms_redirect_path
+          render :new, locals: {redirect_record: redirect_record}
+        end
+
+        # Create redirect
+        # @type POST
+        def create
+          redirect_record = Panda::CMS::Redirect.new(redirect_params)
+          redirect_record.visits ||= 0
+
+          if redirect_record.save
+            redirect_to edit_admin_cms_redirect_path(redirect_record), notice: "Redirect was successfully created."
+          else
+            add_breadcrumb "New Redirect", new_admin_cms_redirect_path
+            render :new, locals: {redirect_record: redirect_record}, status: :unprocessable_entity
+          end
+        end
+
+        # Edit redirect
+        # @type GET
+        def edit
+          add_breadcrumb @redirect_record.origin_path, edit_admin_cms_redirect_path(@redirect_record)
+          render :edit, locals: {redirect_record: @redirect_record}
+        end
+
+        # Update redirect
+        # @type PATCH/PUT
+        def update
+          if @redirect_record.update(redirect_params)
+            redirect_to edit_admin_cms_redirect_path(@redirect_record), notice: "Redirect was successfully updated.", status: :see_other
+          else
+            add_breadcrumb @redirect_record.origin_path, edit_admin_cms_redirect_path(@redirect_record)
+            render :edit, locals: {redirect_record: @redirect_record}, status: :unprocessable_entity
+          end
+        end
+
+        # Delete redirect
+        # @type DELETE
+        def destroy
+          @redirect_record.destroy
+          redirect_to admin_cms_redirects_path, notice: "Redirect was successfully deleted.", status: :see_other
+        end
+
+        private
+
+        def set_redirect
+          @redirect_record = Panda::CMS::Redirect.find(params[:id])
+        end
+
+        def set_initial_breadcrumb
+          add_breadcrumb "Redirects", admin_cms_redirects_path
+        end
+
+        # Only allow a list of trusted parameters through
+        # @type private
+        # @return ActionController::StrongParameters
+        def redirect_params
+          params.require(:redirect).permit(:origin_path, :destination_path, :status_code)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/panda/cms/pages_controller.rb
+++ b/app/controllers/panda/cms/pages_controller.rb
@@ -54,12 +54,12 @@ module Panda
 
         return unless redirect
 
-        redirect.increment!(:visits)
+        redirect.update_columns(visits: redirect.visits + 1, last_visited_at: Time.current)
 
         # Check if the destination is also a redirect
         next_redirect = Panda::CMS::Redirect.find_by(origin_path: redirect.destination_path)
         if next_redirect
-          next_redirect.increment!(:visits)
+          next_redirect.update_columns(visits: next_redirect.visits + 1, last_visited_at: Time.current)
           redirect_to next_redirect.destination_path, status: redirect.status_code and return
         end
 

--- a/app/views/panda/cms/admin/redirects/edit.html.erb
+++ b/app/views/panda/cms/admin/redirects/edit.html.erb
@@ -1,0 +1,43 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: redirect_record.origin_path, level: 1) do |heading| %>
+    <% heading.with_button(
+      action: :delete,
+      text: "Delete",
+      href: admin_cms_redirect_path(redirect_record),
+      data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this redirect?" }
+    ) %>
+  <% end %>
+
+  <%= panda_cms_form_with model: redirect_record, url: admin_cms_redirect_path(redirect_record), method: :patch do |f| %>
+    <%= render Panda::Core::Admin::FormErrorComponent.new(model: redirect_record) %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Redirect Settings" } %>
+
+      <div class="space-y-4">
+        <%= f.text_field :origin_path, placeholder: "/old-page" %>
+        <%= f.text_field :destination_path, placeholder: "/new-page" %>
+        <%= f.select :status_code, [["301 — Permanent", 301], ["302 — Temporary", 302]], { label: "Status Code" } %>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Statistics" } %>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <span class="text-sm text-gray-500">Total Visits</span>
+          <p class="text-lg font-semibold"><%= redirect_record.visits %></p>
+        </div>
+        <div>
+          <span class="text-sm text-gray-500">Last Visited</span>
+          <p class="text-lg font-semibold">
+            <%= redirect_record.last_visited_at ? "#{time_ago_in_words(redirect_record.last_visited_at)} ago" : "Never" %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::FormFooterComponent.new(submit_text: "Save Redirect") %>
+  <% end %>
+<% end %>

--- a/app/views/panda/cms/admin/redirects/index.html.erb
+++ b/app/views/panda/cms/admin/redirects/index.html.erb
@@ -7,11 +7,17 @@
     <% table.column("Origin Path") { |r| block_link_to r.origin_path, edit_admin_cms_redirect_path(r) } %>
     <% table.column("Destination Path") { |r| r.destination_path } %>
     <% table.column("Status Code") do |r| %>
-      <% status_text = r.status_code == 301 ? "Permanent" : "Temporary" %>
-      <% status_symbol = r.status_code == 301 ? :active : :pending %>
+      <% status_text, status_symbol = case r.status_code
+                                     when 301, 308
+                                       ["Permanent", :active]
+                                     when 302, 307
+                                       ["Temporary", :pending]
+                                     else
+                                       ["Unknown", :pending]
+                                     end %>
       <%= render Panda::Core::Admin::TagComponent.new(status: status_symbol, text: "#{r.status_code} — #{status_text}") %>
     <% end %>
-    <% table.column("Visits") { |r| r.visits } %>
+    <% table.column("Visits") { |r| r.visits.to_s } %>
     <% table.column("") do |r| %>
       <%= link_to "Edit", edit_admin_cms_redirect_path(r), class: "text-primary-600 hover:text-primary-700 mr-3" %>
       <%= link_to "Delete", admin_cms_redirect_path(r),

--- a/app/views/panda/cms/admin/redirects/index.html.erb
+++ b/app/views/panda/cms/admin/redirects/index.html.erb
@@ -1,0 +1,22 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: "Redirects", level: 1) do |heading| %>
+    <% heading.with_button(action: :add, text: "New Redirect", href: new_admin_cms_redirect_path) %>
+  <% end %>
+
+  <%= render Panda::Core::Admin::TableComponent.new(term: "redirect", rows: redirects, icon: "fa-solid fa-arrow-right") do |table| %>
+    <% table.column("Origin Path") { |r| block_link_to r.origin_path, edit_admin_cms_redirect_path(r) } %>
+    <% table.column("Destination Path") { |r| r.destination_path } %>
+    <% table.column("Status Code") do |r| %>
+      <% status_text = r.status_code == 301 ? "Permanent" : "Temporary" %>
+      <% status_symbol = r.status_code == 301 ? :active : :pending %>
+      <%= render Panda::Core::Admin::TagComponent.new(status: status_symbol, text: "#{r.status_code} — #{status_text}") %>
+    <% end %>
+    <% table.column("Visits") { |r| r.visits } %>
+    <% table.column("") do |r| %>
+      <%= link_to "Edit", edit_admin_cms_redirect_path(r), class: "text-primary-600 hover:text-primary-700 mr-3" %>
+      <%= link_to "Delete", admin_cms_redirect_path(r),
+        data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this redirect?" },
+        class: "text-red-600 hover:text-red-800" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/panda/cms/admin/redirects/new.html.erb
+++ b/app/views/panda/cms/admin/redirects/new.html.erb
@@ -1,0 +1,19 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: "Add Redirect", level: 1) %>
+
+  <%= panda_cms_form_with model: redirect_record, url: admin_cms_redirects_path, method: :post do |f| %>
+    <%= render Panda::Core::Admin::FormErrorComponent.new(model: redirect_record) %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Redirect Settings" } %>
+
+      <div class="space-y-4">
+        <%= f.text_field :origin_path, placeholder: "/old-page" %>
+        <%= f.text_field :destination_path, placeholder: "/new-page" %>
+        <%= f.select :status_code, [["301 — Permanent", 301], ["302 — Temporary", 302]], { label: "Status Code" } %>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::FormFooterComponent.new(submit_text: "Create Redirect") %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Panda::CMS::Engine.routes.draw do
         resources :block_contents, only: %i[update]
       end
       resources :posts
+      resources :redirects
 
       get "settings", to: "settings#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Panda::CMS::Engine.routes.draw do
         resources :block_contents, only: %i[update]
       end
       resources :posts
-      resources :redirects
+      resources :redirects, except: :show
 
       get "settings", to: "settings#index"
 

--- a/lib/panda/cms/engine/core_config.rb
+++ b/lib/panda/cms/engine/core_config.rb
@@ -49,7 +49,8 @@ module Panda
                   icon: "fa-solid fa-globe",
                   children: [
                     {label: "Menus", path: "#{config.admin_path}/cms/menus"},
-                    {label: "Forms", path: "#{config.admin_path}/cms/forms"}
+                    {label: "Forms", path: "#{config.admin_path}/cms/forms"},
+                    {label: "Redirects", path: "#{config.admin_path}/cms/redirects"}
                   ]
                 }
 

--- a/spec/system/panda/cms/admin/admin_pages_smoke_test_spec.rb
+++ b/spec/system/panda/cms/admin/admin_pages_smoke_test_spec.rb
@@ -116,6 +116,20 @@ RSpec.describe "Admin pages smoke tests", type: :system do
     end
   end
 
+  describe "Redirects management" do
+    it "loads redirects index without errors" do
+      visit "/admin/cms/redirects"
+      expect(page).to have_css("h1")
+      expect(page.status_code).to eq(200)
+    end
+
+    it "loads new redirect form without errors" do
+      visit "/admin/cms/redirects/new"
+      expect(page).to have_css("h1")
+      expect(page.status_code).to eq(200)
+    end
+  end
+
   describe "Files management" do
     it "loads files index without errors" do
       visit "/admin/cms/files"

--- a/spec/system/panda/cms/admin/redirects/redirects_management_spec.rb
+++ b/spec/system/panda/cms/admin/redirects/redirects_management_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Redirects Management", type: :system do
+  let!(:admin_user) { create_admin_user }
+
+  let!(:redirect_301) do
+    Panda::CMS::Redirect.create!(
+      origin_path: "/old-page",
+      destination_path: "/new-page",
+      status_code: 301,
+      visits: 5
+    )
+  end
+
+  let!(:redirect_302) do
+    Panda::CMS::Redirect.create!(
+      origin_path: "/temp-page",
+      destination_path: "/current-page",
+      status_code: 302,
+      visits: 0
+    )
+  end
+
+  before do
+    login_as_admin
+  end
+
+  describe "viewing redirects list" do
+    it "shows the redirects index page" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_content("Redirects", wait: 10)
+    end
+
+    it "displays existing redirects" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_content("/old-page", wait: 10)
+      expect(page).to have_content("/new-page")
+      expect(page).to have_content("/temp-page")
+      expect(page).to have_content("/current-page")
+    end
+
+    it "shows status code tags" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_content("Permanent", wait: 10)
+      expect(page).to have_content("Temporary")
+    end
+
+    it "shows visit counts" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_content("Visits", wait: 10)
+      # The redirect_301 fixture has 5 visits
+      within(".table-row-group") do
+        expect(page).to have_content("5")
+      end
+    end
+
+    it "has a button to create a new redirect" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_css("a[href*='/redirects/new']", wait: 10)
+    end
+
+    it "has links to edit each redirect" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_link("/old-page", wait: 10)
+    end
+  end
+
+  describe "creating a new redirect" do
+    it "shows the new redirect form" do
+      visit "/admin/cms/redirects/new"
+
+      expect(page).to have_content("New Redirect", wait: 10)
+      expect(page).to have_field("Origin path")
+      expect(page).to have_field("Destination path")
+    end
+
+    it "creates a redirect with valid data" do
+      visit "/admin/cms/redirects/new"
+
+      fill_in "Origin path", with: "/blog/old-post"
+      fill_in "Destination path", with: "/blog/new-post"
+      select "301 — Permanent", from: "Status Code"
+
+      click_button "Create Redirect"
+
+      expect(page).to have_content(/successfully created/i, wait: 10)
+
+      new_redirect = Panda::CMS::Redirect.find_by(origin_path: "/blog/old-post")
+      expect(new_redirect).not_to be_nil
+      expect(new_redirect.destination_path).to eq("/blog/new-post")
+      expect(new_redirect.status_code).to eq(301)
+    end
+
+    it "shows validation errors when origin path is missing" do
+      visit "/admin/cms/redirects/new"
+
+      expect(page).to have_css("form", wait: 5)
+
+      fill_in "Destination path", with: "/new-path"
+      click_button "Create Redirect"
+
+      expect(page).to have_content("can't be blank", wait: 5)
+    end
+
+    it "shows validation errors when paths don't start with /" do
+      visit "/admin/cms/redirects/new"
+
+      expect(page).to have_css("form", wait: 5)
+
+      fill_in "Origin path", with: "no-slash"
+      fill_in "Destination path", with: "/valid-path"
+      click_button "Create Redirect"
+
+      expect(page).to have_content("must start with a forward slash", wait: 5)
+    end
+  end
+
+  describe "editing a redirect" do
+    it "shows the edit form with existing values" do
+      visit "/admin/cms/redirects/#{redirect_301.id}/edit"
+
+      expect(page).to have_field("Origin path", with: "/old-page", wait: 10)
+      expect(page).to have_field("Destination path", with: "/new-page")
+    end
+
+    it "updates a redirect" do
+      visit "/admin/cms/redirects/#{redirect_301.id}/edit"
+
+      fill_in "Origin path", with: "/updated-origin"
+      fill_in "Destination path", with: "/updated-destination"
+
+      click_button "Save Redirect"
+
+      expect(page).to have_content(/successfully updated/i, wait: 10)
+
+      redirect_301.reload
+      expect(redirect_301.origin_path).to eq("/updated-origin")
+      expect(redirect_301.destination_path).to eq("/updated-destination")
+    end
+
+    it "shows statistics panel" do
+      visit "/admin/cms/redirects/#{redirect_301.id}/edit"
+
+      expect(page).to have_content("Statistics", wait: 10)
+      expect(page).to have_content("Total Visits")
+      expect(page).to have_content("5")
+    end
+
+    it "has a delete button" do
+      visit "/admin/cms/redirects/#{redirect_301.id}/edit"
+
+      expect(page).to have_css("a[data-turbo-method='delete']", wait: 10)
+    end
+  end
+
+  describe "deleting a redirect" do
+    it "has delete links on the index page" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_css("a[data-turbo-method='delete']", wait: 10)
+    end
+
+    it "can delete a redirect" do
+      redirect_to_delete = Panda::CMS::Redirect.create!(
+        origin_path: "/delete-me",
+        destination_path: "/somewhere",
+        status_code: 301,
+        visits: 0
+      )
+
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_content("/delete-me", wait: 10)
+
+      expect {
+        redirect_to_delete.destroy
+      }.to change(Panda::CMS::Redirect, :count).by(-1)
+    end
+  end
+
+  describe "breadcrumbs" do
+    it "shows breadcrumb navigation on index" do
+      visit "/admin/cms/redirects"
+
+      expect(page).to have_css("nav[aria-label='Breadcrumb']", wait: 10)
+      expect(page).to have_content("Redirects")
+    end
+
+    it "shows breadcrumb navigation on new" do
+      visit "/admin/cms/redirects/new"
+
+      expect(page).to have_css("nav[aria-label='Breadcrumb']", wait: 10)
+      expect(page).to have_link("Redirects")
+      expect(page).to have_content("New Redirect")
+    end
+
+    it "shows breadcrumb navigation on edit" do
+      visit "/admin/cms/redirects/#{redirect_301.id}/edit"
+
+      expect(page).to have_css("nav[aria-label='Breadcrumb']", wait: 10)
+      expect(page).to have_link("Redirects")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds full CRUD admin interface for managing URL redirects (301/302)
- Includes index, new, edit views using existing Panda Core admin components (ContainerComponent, TableComponent, PanelComponent, etc.)
- Adds `RedirectsController` with index, new, create, edit, update, and destroy actions
- Registers "Redirects" under the Website navigation section alongside Menus and Forms
- Displays redirect statistics (visit count, last visited) on the edit page

## Test plan
- [ ] Verify redirects index page loads at `/admin/cms/redirects`
- [ ] Create a new redirect with origin path, destination path, and status code
- [ ] Edit an existing redirect and verify changes persist
- [ ] Delete a redirect and confirm it's removed from the index
- [ ] Verify 301 (Permanent) and 302 (Temporary) status code tags display correctly
- [ ] Confirm "Redirects" appears in the Website navigation menu
- [ ] Run `bundle exec rspec` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)