### PR TITLE
Replace period selector with DropdownComponent and conditionally show visit stats

### DIFF
--- a/app/javascript/panda/cms/controllers/dashboard_controller.js
+++ b/app/javascript/panda/cms/controllers/dashboard_controller.js
@@ -1,10 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  changePeriod(event) {
-    const period = event.target.value
-    const url = new URL(window.location)
-    url.searchParams.set("period", period)
-    window.location = url.toString()
-  }
 }

--- a/app/views/panda/cms/admin/_widget_header.html.erb
+++ b/app/views/panda/cms/admin/_widget_header.html.erb
@@ -1,13 +1,16 @@
 <div class="flex items-center justify-between pb-4 mb-6 border-b border-gray-200">
   <h3 class="text-sm font-semibold text-gray-700"><%= title %></h3>
   <% if local_assigns[:period_options].present? %>
-    <select data-action="change->dashboard#changePeriod"
-            class="text-xs text-gray-500 border border-gray-200 rounded-lg px-2 py-1 bg-white"
-            aria-label="Analytics period">
-      <% period_options.each do |label, value| %>
-        <option value="<%= value %>" <%= "selected" if value.to_s == local_assigns[:selected_period].to_s %>><%= label %></option>
+    <% selected_label = period_options.find { |_, v| v.to_s == local_assigns[:selected_period].to_s }&.first || period_options.first&.first %>
+    <%= render Panda::Core::Admin::DropdownComponent.new do |dropdown| %>
+      <% dropdown.with_trigger_slot do %>
+        <span class="text-xs text-gray-500"><%= selected_label %></span>
+        <i class="fa-solid fa-chevron-down text-xs" aria-hidden="true"></i>
       <% end %>
-    </select>
+      <% period_options.each do |label, value| %>
+        <% dropdown.with_item(label: label, href: "?period=#{value}") %>
+      <% end %>
+    <% end %>
   <% elsif local_assigns[:subtitle].present? %>
     <span class="text-xs text-gray-500"><%= subtitle %></span>
   <% end %>

--- a/app/views/panda/cms/admin/dashboard/show.html.erb
+++ b/app/views/panda/cms/admin/dashboard/show.html.erb
@@ -1,17 +1,11 @@
 <% period = @period || 30.days %>
-<div class="" data-controller="dashboard">
+<div class="">
   <%= render Panda::Core::Admin::ContainerComponent.new do |container| %>
     <% container.with_heading_slot(text: "Dashboard", level: 1) do |heading| %>
       <% heading.with_button(action: :add, text: "Add Page", href: new_admin_cms_page_path) %>
     <% end %>
     <% ga_available = Panda::CMS::Analytics.available? rescue false %>
-    <% unless ga_available %>
-      <dl class="grid grid-cols-1 gap-5 mt-5 sm:grid-cols-3">
-        <%= render Panda::Core::Admin::StatisticsComponent.new(metric: "Views Today", value: Panda::CMS::Visit.group_by_day(:visited_at, last: 1).count.values.first || 0) %>
-        <%= render Panda::Core::Admin::StatisticsComponent.new(metric: "Views Last Week", value: Panda::CMS::Visit.group_by_week(:visited_at, last: 1).count.values.first || 0) %>
-        <%= render Panda::Core::Admin::StatisticsComponent.new(metric: "Views Last Month", value: Panda::CMS::Visit.group_by_month(:visited_at, last: 1).count.values.first || 0) %>
-      </dl>
-    <% end %>
+    <% has_local_visits = !ga_available && Panda::CMS::Visit.exists? %>
 
     <% if ga_available %>
       <!-- Analytics widgets when GA is configured -->
@@ -27,8 +21,14 @@
       <div class="grid grid-cols-1 gap-5 mt-5">
         <%= render Panda::CMS::Admin::RecentPagesWidgetComponent.new(limit: 10) %>
       </div>
-    <% else %>
-      <!-- Local analytics widgets when GA is not configured -->
+    <% elsif has_local_visits %>
+      <!-- Local analytics widgets when visit data exists -->
+      <dl class="grid grid-cols-1 gap-5 mt-5 sm:grid-cols-3">
+        <%= render Panda::Core::Admin::StatisticsComponent.new(metric: "Views Today", value: Panda::CMS::Visit.group_by_day(:visited_at, last: 1).count.values.first || 0) %>
+        <%= render Panda::Core::Admin::StatisticsComponent.new(metric: "Views Last Week", value: Panda::CMS::Visit.group_by_week(:visited_at, last: 1).count.values.first || 0) %>
+        <%= render Panda::Core::Admin::StatisticsComponent.new(metric: "Views Last Month", value: Panda::CMS::Visit.group_by_month(:visited_at, last: 1).count.values.first || 0) %>
+      </dl>
+
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-5 mt-8">
         <%= render Panda::CMS::Admin::AnalyticsWidgetComponent.new(period: period) %>
         <%= render Panda::CMS::Admin::PopularPagesComponent.new(

--- a/spec/components/panda/cms/admin/analytics_widget_component_spec.rb
+++ b/spec/components/panda/cms/admin/analytics_widget_component_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe Panda::CMS::Admin::AnalyticsWidgetComponent, type: :component do
     it "displays the period selector" do
       render_inline(described_class.new(period: 30.days))
 
-      expect(page).to have_css("select option[selected]", text: "Last 30 days")
+      expect(page).to have_text("Last 30 days")
+      expect(page).to have_css("[role='menuitem']", text: "Last 7 days")
     end
 
     context "when analytics is available" do

--- a/spec/components/panda/cms/admin/page_views_chart_component_spec.rb
+++ b/spec/components/panda/cms/admin/page_views_chart_component_spec.rb
@@ -109,7 +109,8 @@ RSpec.describe Panda::CMS::Admin::PageViewsChartComponent, type: :component do
     it "displays the period selector" do
       render_inline(described_class.new(period: 7.days))
 
-      expect(page).to have_css("select option[selected]", text: "Last 7 days")
+      expect(page).to have_text("Last 7 days")
+      expect(page).to have_css("[role='menuitem']", text: "Last 30 days")
     end
 
     context "when no chart data is available" do

--- a/spec/components/panda/cms/admin/top_referrers_widget_component_spec.rb
+++ b/spec/components/panda/cms/admin/top_referrers_widget_component_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe Panda::CMS::Admin::TopReferrersWidgetComponent, type: :component 
     it "displays the period selector" do
       render_inline(described_class.new(period: 7.days))
 
-      expect(page).to have_css("select option[selected]", text: "Last 7 days")
+      expect(page).to have_text("Last 7 days")
+      expect(page).to have_css("[role='menuitem']", text: "Last 30 days")
     end
 
     context "when referrer data is available" do


### PR DESCRIPTION
## Summary
- Replaces the native `<select>` period selector in analytics widgets with `Panda::Core::Admin::DropdownComponent` for consistent admin UI styling
- Removes the `changePeriod` Stimulus action from `dashboard_controller.js` — period changes now use simple link navigation (`?period=...`) via the dropdown items
- Moves the visit statistics block (Views Today/Week/Month) to only display when local visit data actually exists, avoiding empty stats on fresh installs without visit data
- Updates component specs to match the new dropdown markup (`[role='menuitem']` instead of `select option[selected]`)

## Test plan
- [ ] Verify the period dropdown renders correctly on analytics widgets
- [ ] Confirm clicking a period option navigates and updates the dashboard
- [ ] Check that a fresh install without visit data doesn't show empty statistics
- [ ] Run `bundle exec rspec spec/components/panda/cms/admin/` to verify updated specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)