### PR TITLE
Add admin CRUD for managing redirects

### DIFF
--- a/app/controllers/panda/cms/admin/redirects_controller.rb
+++ b/app/controllers/panda/cms/admin/redirects_controller.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    module Admin
+      class RedirectsController < ::Panda::CMS::Admin::BaseController
+        before_action :set_initial_breadcrumb
+        before_action :set_redirect, only: %i[edit update destroy]
+
+        # Lists all redirects
+        # @type GET
+        # @return ActiveRecord::Collection A list of all redirects
+        def index
+          redirects = Panda::CMS::Redirect.order(:origin_path)
+          render :index, locals: {redirects: redirects}
+        end
+
+        # New redirect
+        # @type GET
+        def new
+          redirect_record = Panda::CMS::Redirect.new(status_code: 301, visits: 0)
+          add_breadcrumb "New Redirect", new_admin_cms_redirect_path
+          render :new, locals: {redirect_record: redirect_record}
+        end
+
+        # Create redirect
+        # @type POST
+        def create
+          redirect_record = Panda::CMS::Redirect.new(redirect_params)
+          redirect_record.visits ||= 0
+
+          if redirect_record.save
+            redirect_to edit_admin_cms_redirect_path(redirect_record), notice: "Redirect was successfully created."
+          else
+            add_breadcrumb "New Redirect", new_admin_cms_redirect_path
+            render :new, locals: {redirect_record: redirect_record}, status: :unprocessable_entity
+          end
+        end
+
+        # Edit redirect
+        # @type GET
+        def edit
+          add_breadcrumb @redirect_record.origin_path, edit_admin_cms_redirect_path(@redirect_record)
+          render :edit, locals: {redirect_record: @redirect_record}
+        end
+
+        # Update redirect
+        # @type PATCH/PUT
+        def update
+          if @redirect_record.update(redirect_params)
+            redirect_to edit_admin_cms_redirect_path(@redirect_record), notice: "Redirect was successfully updated.", status: :see_other
+          else
+            add_breadcrumb @redirect_record.origin_path, edit_admin_cms_redirect_path(@redirect_record)
+            render :edit, locals: {redirect_record: @redirect_record}, status: :unprocessable_entity
+          end
+        end
+
+        # Delete redirect
+        # @type DELETE
+        def destroy
+          @redirect_record.destroy
+          redirect_to admin_cms_redirects_path, notice: "Redirect was successfully deleted.", status: :see_other
+        end
+
+        private
+
+        def set_redirect
+          @redirect_record = Panda::CMS::Redirect.find(params[:id])
+        end
+
+        def set_initial_breadcrumb
+          add_breadcrumb "Redirects", admin_cms_redirects_path
+        end
+
+        # Only allow a list of trusted parameters through
+        # @type private
+        # @return ActionController::StrongParameters
+        def redirect_params
+          params.require(:redirect).permit(:origin_path, :destination_path, :status_code)
+        end
+      end
+    end
+  end
+end

--- a/app/views/panda/cms/admin/redirects/edit.html.erb
+++ b/app/views/panda/cms/admin/redirects/edit.html.erb
@@ -1,0 +1,43 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: redirect_record.origin_path, level: 1) do |heading| %>
+    <% heading.with_button(
+      action: :delete,
+      text: "Delete",
+      href: admin_cms_redirect_path(redirect_record),
+      data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this redirect?" }
+    ) %>
+  <% end %>
+
+  <%= panda_cms_form_with model: redirect_record, url: admin_cms_redirect_path(redirect_record), method: :patch do |f| %>
+    <%= render Panda::Core::Admin::FormErrorComponent.new(model: redirect_record) %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Redirect Settings" } %>
+
+      <div class="space-y-4">
+        <%= f.text_field :origin_path, placeholder: "/old-page" %>
+        <%= f.text_field :destination_path, placeholder: "/new-page" %>
+        <%= f.select :status_code, [["301 — Permanent", 301], ["302 — Temporary", 302]], { label: "Status Code" } %>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Statistics" } %>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <span class="text-sm text-gray-500">Total Visits</span>
+          <p class="text-lg font-semibold"><%= redirect_record.visits %></p>
+        </div>
+        <div>
+          <span class="text-sm text-gray-500">Last Visited</span>
+          <p class="text-lg font-semibold">
+            <%= redirect_record.last_visited_at ? "#{time_ago_in_words(redirect_record.last_visited_at)} ago" : "Never" %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::FormFooterComponent.new(submit_text: "Save Redirect") %>
+  <% end %>
+<% end %>

--- a/app/views/panda/cms/admin/redirects/index.html.erb
+++ b/app/views/panda/cms/admin/redirects/index.html.erb
@@ -1,0 +1,22 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: "Redirects", level: 1) do |heading| %>
+    <% heading.with_button(action: :add, text: "New Redirect", href: new_admin_cms_redirect_path) %>
+  <% end %>
+
+  <%= render Panda::Core::Admin::TableComponent.new(term: "redirect", rows: redirects, icon: "fa-solid fa-arrow-right") do |table| %>
+    <% table.column("Origin Path") { |r| block_link_to r.origin_path, edit_admin_cms_redirect_path(r) } %>
+    <% table.column("Destination Path") { |r| r.destination_path } %>
+    <% table.column("Status Code") do |r| %>
+      <% status_text = r.status_code == 301 ? "Permanent" : "Temporary" %>
+      <% status_symbol = r.status_code == 301 ? :active : :pending %>
+      <%= render Panda::Core::Admin::TagComponent.new(status: status_symbol, text: "#{r.status_code} — #{status_text}") %>
+    <% end %>
+    <% table.column("Visits") { |r| r.visits } %>
+    <% table.column("") do |r| %>
+      <%= link_to "Edit", edit_admin_cms_redirect_path(r), class: "text-primary-600 hover:text-primary-700 mr-3" %>
+      <%= link_to "Delete", admin_cms_redirect_path(r),
+        data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this redirect?" },
+        class: "text-red-600 hover:text-red-800" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/panda/cms/admin/redirects/new.html.erb
+++ b/app/views/panda/cms/admin/redirects/new.html.erb
@@ -1,0 +1,19 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: "Add Redirect", level: 1) %>
+
+  <%= panda_cms_form_with model: redirect_record, url: admin_cms_redirects_path, method: :post do |f| %>
+    <%= render Panda::Core::Admin::FormErrorComponent.new(model: redirect_record) %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Redirect Settings" } %>
+
+      <div class="space-y-4">
+        <%= f.text_field :origin_path, placeholder: "/old-page" %>
+        <%= f.text_field :destination_path, placeholder: "/new-page" %>
+        <%= f.select :status_code, [["301 — Permanent", 301], ["302 — Temporary", 302]], { label: "Status Code" } %>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::FormFooterComponent.new(submit_text: "Create Redirect") %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Panda::CMS::Engine.routes.draw do
         resources :block_contents, only: %i[update]
       end
       resources :posts
+      resources :redirects
 
       get "settings", to: "settings#index"
 

--- a/lib/panda/cms/engine/core_config.rb
+++ b/lib/panda/cms/engine/core_config.rb
@@ -49,7 +49,8 @@ module Panda
                   icon: "fa-solid fa-globe",
                   children: [
                     {label: "Menus", path: "#{config.admin_path}/cms/menus"},
-                    {label: "Forms", path: "#{config.admin_path}/cms/forms"}
+                    {label: "Forms", path: "#{config.admin_path}/cms/forms"},
+                    {label: "Redirects", path: "#{config.admin_path}/cms/redirects"}
                   ]
                 }
 


### PR DESCRIPTION
## Summary
- The `Panda::CMS::Redirect` model and `panda_cms_redirects` table already existed but could only be managed via Rails console or were auto-created when a page path changed
- Adds a full admin CRUD interface under **Website > Redirects** with index, new, create, edit, update, and destroy actions
- Index table shows origin path, destination path, status code (as colored tags: 301 Permanent / 302 Temporary), and visit count
- Edit view includes a read-only statistics panel showing total visits and last visited timestamp
- Controller follows existing patterns (inherits `BaseController`, uses locals, breadcrumbs, flash messages)

## Test plan
- [x] All 20 redirect model specs pass
- [x] All 269 model specs pass (0 failures)
- [x] All 16 admin smoke tests pass (0 failures)
- [x] Brakeman: 0 security warnings
- [x] StandardRB: no offenses
- [x] ERBLint: no errors
- [x] Zeitwerk: all good
- [ ] Manually verify at `/manage/cms/redirects` — create, edit, delete a redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)