### PR TITLE
feat: Wire up editorjs-undo, link-autocomplete, and search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 7fb6e96f11d31f56a9e67663b2f41d63472e811b
+  revision: a2c3e3ae1e465a7da1a69b1ede2f9b61ce270ad1
   branch: main
   specs:
     panda-core (0.14.4)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: cb5bc1c5dd8668c2ff4c976db01146554df446ab
+  revision: f8d20d09d578b1bdf1cafb96cd3b740c392c51ad
   branch: main
   specs:
     panda-editor (0.8.3)

--- a/app/controllers/panda/cms/admin/link_metadata_controller.rb
+++ b/app/controllers/panda/cms/admin/link_metadata_controller.rb
@@ -4,8 +4,6 @@ module Panda
   module CMS
     module Admin
       class LinkMetadataController < ::Panda::CMS::Admin::BaseController
-        skip_forgery_protection only: [:create]
-
         def create
           url = params[:url].to_s.strip
           if url.blank?

--- a/app/controllers/panda/cms/admin/link_metadata_controller.rb
+++ b/app/controllers/panda/cms/admin/link_metadata_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    module Admin
+      class LinkMetadataController < ::Panda::CMS::Admin::BaseController
+        skip_forgery_protection only: [:create]
+
+        def create
+          url = params[:url].to_s.strip
+          if url.blank?
+            return render json: {success: 0, meta: {}}
+          end
+
+          meta = Panda::CMS::LinkMetadataService.call(url)
+          render json: {success: 1, meta: meta}
+        rescue => e
+          Rails.logger.warn("[Panda CMS] Link metadata fetch failed for #{url}: #{e.message}")
+          render json: {success: 0, meta: {}}
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/panda/cms/controllers/editor_form_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_form_controller.js
@@ -80,6 +80,8 @@ export default class extends Controller {
       const initialContent = this.getInitialContent();
       console.debug("[Panda CMS] Using initial content:", initialContent);
 
+      const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+
       const config = {
         ...getEditorConfig(holderId, initialContent),
         holder: holderId,
@@ -137,7 +139,10 @@ export default class extends Controller {
           linkTool: {
             class: window.LinkTool,
             config: {
-              endpoint: window.PANDA_CMS_EDITOR_JS_ENDPOINTS?.linkMetadata
+              endpoint: window.PANDA_CMS_EDITOR_JS_ENDPOINTS?.linkMetadata,
+              headers: {
+                'X-CSRF-Token': csrfToken
+              }
             }
           },
           attaches: {
@@ -145,7 +150,10 @@ export default class extends Controller {
             config: {
               endpoint: window.PANDA_CMS_EDITOR_JS_ENDPOINTS?.fileUpload,
               field: 'file',
-              buttonText: 'Select file to upload'
+              buttonText: 'Select file to upload',
+              additionalRequestHeaders: {
+                'X-CSRF-Token': csrfToken
+              }
             }
           },
           link: {

--- a/app/javascript/panda/cms/controllers/editor_iframe_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_iframe_controller.js
@@ -266,6 +266,8 @@ export default class extends Controller {
         fileUpload: this.fileUploadUrlValue || undefined,
         editorSearch: this.editorSearchUrlValue || undefined,
       }
+      // Pass CSRF token from parent document to iframe window for EditorJS tool requests
+      iframeWindow.PANDA_CMS_CSRF_TOKEN = parent.document.querySelector('meta[name="csrf-token"]')?.content
     }
 
     // Get all editable elements

--- a/app/javascript/panda/cms/controllers/editor_iframe_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_iframe_controller.js
@@ -22,7 +22,10 @@ export default class extends Controller {
     pageId: Number,
     adminPath: String,
     autosave: Boolean,
-    assets: String
+    assets: String,
+    linkMetadataUrl: String,
+    fileUploadUrl: String,
+    editorSearchUrl: String
   }
 
   connect() {
@@ -255,6 +258,16 @@ export default class extends Controller {
     console.debug("[Panda CMS] Starting editor initialization")
     this.logLayoutState("initializeEditors start")
 
+    // Set endpoint URLs for EditorJS tools (link, attaches) in the iframe window
+    const iframeWindow = this.frameDocument.defaultView || this.frame.contentWindow
+    if (iframeWindow) {
+      iframeWindow.PANDA_CMS_EDITOR_JS_ENDPOINTS = {
+        linkMetadata: this.linkMetadataUrlValue || undefined,
+        fileUpload: this.fileUploadUrlValue || undefined,
+        editorSearch: this.editorSearchUrlValue || undefined,
+      }
+    }
+
     // Get all editable elements
     const plainTextElements = this.body.querySelectorAll('[data-editable-kind="plain_text"], [data-editable-kind="markdown"], [data-editable-kind="html"]')
     const richTextElements = this.body.querySelectorAll('[data-editable-kind="rich_text"]')
@@ -356,7 +369,9 @@ export default class extends Controller {
         'quote': 'Quote',
         'simple-image': 'SimpleImage',
         'table': 'Table',
-        'embed': 'Embed'
+        'embed': 'Embed',
+        'link': 'LinkTool',
+        'attaches': 'AttachesTool'
       }
 
       const check = () => {

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -35,6 +35,13 @@ module Panda
 
       scope :ordered, -> { order(:lft) }
 
+      def self.editor_search(query, limit: 5)
+        where(status: :active)
+          .where("title ILIKE :q OR path ILIKE :q", q: "%#{sanitize_sql_like(query)}%")
+          .limit(limit)
+          .map { |p| {href: p.path, name: p.title, description: p.path} }
+      end
+
       enum :status, {
         active: "active",
         draft: "draft",

--- a/app/models/panda/cms/post.rb
+++ b/app/models/panda/cms/post.rb
@@ -27,6 +27,14 @@ module Panda
         }
 
       scope :ordered, -> { order(published_at: :desc) }
+
+      def self.editor_search(query, limit: 5)
+        posts_prefix = Panda::CMS.config.posts[:prefix]
+        where(status: :active)
+          .where("title ILIKE :q OR slug ILIKE :q", q: "%#{sanitize_sql_like(query)}%")
+          .limit(limit)
+          .map { |p| {href: "#{posts_prefix}#{p.slug}", name: p.title, description: "Post"} }
+      end
       scope :with_user, -> { includes(:user) }
       scope :with_author, -> { includes(:author) }
 

--- a/app/services/panda/cms/link_metadata_service.rb
+++ b/app/services/panda/cms/link_metadata_service.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require "nokogiri"
+
+module Panda
+  module CMS
+    class LinkMetadataService
+      MAX_REDIRECTS = 3
+      CONNECT_TIMEOUT = 5
+      READ_TIMEOUT = 5
+      MAX_RESPONSE_SIZE = 1_048_576 # 1 MB
+
+      def self.call(url)
+        new(url).call
+      end
+
+      def initialize(url)
+        @url = url
+      end
+
+      def call
+        validate_url!
+        html = fetch_html(@url, MAX_REDIRECTS)
+        parse_metadata(html)
+      end
+
+      private
+
+      def validate_url!
+        uri = URI.parse(@url)
+        unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+          raise ArgumentError, "Only http and https URLs are allowed"
+        end
+      rescue URI::InvalidURIError
+        raise ArgumentError, "Invalid URL"
+      end
+
+      def fetch_html(url, redirects_remaining)
+        uri = URI.parse(url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == "https")
+        http.open_timeout = CONNECT_TIMEOUT
+        http.read_timeout = READ_TIMEOUT
+
+        request = Net::HTTP::Get.new(uri.request_uri)
+        request["User-Agent"] = "PandaCMS LinkTool/1.0"
+        request["Accept"] = "text/html"
+
+        response = http.request(request)
+
+        case response
+        when Net::HTTPRedirection
+          if redirects_remaining > 0
+            location = response["location"]
+            # Handle relative redirects
+            location = URI.join(url, location).to_s unless location.start_with?("http")
+            fetch_html(location, redirects_remaining - 1)
+          else
+            raise "Too many redirects"
+          end
+        when Net::HTTPSuccess
+          body = response.body.to_s
+          if body.bytesize > MAX_RESPONSE_SIZE
+            body = body.byteslice(0, MAX_RESPONSE_SIZE)
+          end
+          body.force_encoding("UTF-8")
+        else
+          raise "HTTP #{response.code}"
+        end
+      end
+
+      def parse_metadata(html)
+        doc = Nokogiri::HTML(html)
+
+        title = og_content(doc, "og:title") || doc.at_css("title")&.text
+        description = og_content(doc, "og:description") ||
+          doc.at_css('meta[name="description"]')&.[]("content")
+        image_url = og_content(doc, "og:image")
+
+        meta = {
+          title: title.to_s.strip.truncate(200),
+          description: description.to_s.strip.truncate(500)
+        }
+
+        meta[:image] = {url: image_url} if image_url.present?
+
+        meta
+      end
+
+      def og_content(doc, property)
+        doc.at_css("meta[property='#{property}']")&.[]("content")
+      end
+    end
+  end
+end

--- a/app/views/panda/cms/admin/pages/edit.html.erb
+++ b/app/views/panda/cms/admin/pages/edit.html.erb
@@ -172,7 +172,10 @@
         editor_iframe_page_id_value: @page.id,
         editor_iframe_admin_path_value: "#{admin_cms_dashboard_url}",
         editor_iframe_autosave_value: false,
-        editor_iframe_assets_value: panda_cms_injectable_assets
+        editor_iframe_assets_value: panda_cms_injectable_assets,
+        editor_iframe_link_metadata_url_value: admin_cms_link_metadata_index_path,
+        editor_iframe_file_upload_url_value: admin_cms_files_path,
+        editor_iframe_editor_search_url_value: panda_core.admin_editor_search_path
       } %>
 
   <%# Vanilla JS character counters - works independently of Stimulus %>

--- a/app/views/panda/cms/admin/pages/edit.html.erb
+++ b/app/views/panda/cms/admin/pages/edit.html.erb
@@ -173,7 +173,7 @@
         editor_iframe_admin_path_value: "#{admin_cms_dashboard_url}",
         editor_iframe_autosave_value: false,
         editor_iframe_assets_value: panda_cms_injectable_assets,
-        editor_iframe_link_metadata_url_value: admin_cms_link_metadata_index_path,
+        editor_iframe_link_metadata_url_value: admin_cms_link_metadata_path,
         editor_iframe_file_upload_url_value: admin_cms_files_path,
         editor_iframe_editor_search_url_value: panda_core.admin_editor_search_path
       } %>

--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -24,7 +24,7 @@
   <% editor_id = "editor_#{dom_id(post, :content)}" %>
   <div data-controller="editor-form"
        data-editor-form-editor-id-value="<%= editor_id %>"
-       data-editor-form-link-metadata-url-value="<%= admin_cms_link_metadata_index_path %>"
+       data-editor-form-link-metadata-url-value="<%= admin_cms_link_metadata_path %>"
        data-editor-form-file-upload-url-value="<%= admin_cms_files_path %>"
        data-editor-form-editor-search-url-value="<%= panda_core.admin_editor_search_path %>">
     <%= f.hidden_field :content,

--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -23,7 +23,10 @@
 
   <% editor_id = "editor_#{dom_id(post, :content)}" %>
   <div data-controller="editor-form"
-       data-editor-form-editor-id-value="<%= editor_id %>">
+       data-editor-form-editor-id-value="<%= editor_id %>"
+       data-editor-form-link-metadata-url-value="<%= admin_cms_link_metadata_index_path %>"
+       data-editor-form-file-upload-url-value="<%= admin_cms_files_path %>"
+       data-editor-form-editor-search-url-value="<%= panda_core.admin_editor_search_path %>">
     <%= f.hidden_field :content,
         data: {
           editor_form_target: "hiddenField",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Panda::CMS::Engine.routes.draw do
     namespace admin_path.delete_prefix("/").to_sym, path: "#{admin_path}/cms", as: :admin_cms, module: :admin do
       resources :files
       resources :forms
+      resources :link_metadata, only: [:create]
       resources :menus
       resources :pages do
         resources :block_contents, only: %i[update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Panda::CMS::Engine.routes.draw do
     namespace admin_path.delete_prefix("/").to_sym, path: "#{admin_path}/cms", as: :admin_cms, module: :admin do
       resources :files
       resources :forms
-      resources :link_metadata, only: [:create]
+      post "link_metadata", to: "link_metadata#create", as: :link_metadata
       resources :menus
       resources :pages do
         resources :block_contents, only: %i[update]

--- a/lib/panda/cms/engine.rb
+++ b/lib/panda/cms/engine.rb
@@ -59,6 +59,20 @@ module Panda
         end
       end
 
+      # Register search providers for editor link-autocomplete
+      initializer "panda_cms.search_providers" do
+        ActiveSupport.on_load(:active_record) do
+          Panda::Core::SearchRegistry.register(
+            name: "pages",
+            search_class: Panda::CMS::Page
+          )
+          Panda::Core::SearchRegistry.register(
+            name: "posts",
+            search_class: Panda::CMS::Post
+          )
+        end
+      end
+
       # Configure custom error pages in production-like environments
       # This enables Panda CMS's custom 404, 500, and other error pages
       initializer "panda.cms.custom_error_pages", after: :load_config_initializers do |app|

--- a/spec/models/panda/cms/post_spec.rb
+++ b/spec/models/panda/cms/post_spec.rb
@@ -38,6 +38,72 @@ RSpec.describe Panda::CMS::Post, type: :model do
     end
   end
 
+  describe ".editor_search" do
+    let(:admin_user) { create_admin_user }
+
+    let!(:active_post) do
+      Panda::CMS::Post.create!(
+        title: "Active Post",
+        slug: "/active-post",
+        user: admin_user,
+        author: admin_user,
+        status: "active"
+      )
+    end
+
+    let!(:draft_post) do
+      Panda::CMS::Post.create!(
+        title: "Draft Post",
+        slug: "/draft-post",
+        user: admin_user,
+        author: admin_user,
+        status: "draft"
+      )
+    end
+
+    let!(:another_active_post) do
+      Panda::CMS::Post.create!(
+        title: "Another Active Post",
+        slug: "/another-active-post",
+        user: admin_user,
+        author: admin_user,
+        status: "active"
+      )
+    end
+
+    it "returns only active records" do
+      results = Panda::CMS::Post.editor_search("post")
+      names = results.map { |r| r[:name] }
+      expect(names).to include("Active Post")
+      expect(names).not_to include("Draft Post")
+    end
+
+    it "matches by title" do
+      results = Panda::CMS::Post.editor_search("Another Active")
+      expect(results.length).to eq(1)
+      expect(results.first[:name]).to eq("Another Active Post")
+    end
+
+    it "matches by slug" do
+      results = Panda::CMS::Post.editor_search("active-post")
+      expect(results.map { |r| r[:name] }).to include("Active Post")
+    end
+
+    it "respects limit" do
+      results = Panda::CMS::Post.editor_search("post", limit: 1)
+      expect(results.length).to eq(1)
+    end
+
+    it "returns correct hash structure" do
+      results = Panda::CMS::Post.editor_search("Active Post")
+      result = results.find { |r| r[:name] == "Active Post" }
+      expect(result).to include(:href, :name, :description)
+      expect(result[:href]).to match(/blog/)
+      expect(result[:name]).to eq("Active Post")
+      expect(result[:description]).to eq("Post")
+    end
+  end
+
   describe "SEO functionality" do
     let(:admin_user) { create_admin_user }
     let(:post) do


### PR DESCRIPTION
Add editor_search to Page/Post models, register as SearchRegistry providers, wire up Stimulus controllers and ERB views for undo and link-autocomplete. Depends on panda-core#98 and panda-editor#4.