### PR TITLE
Fix redirects test expecting delete links on index page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 7fb6e96f11d31f56a9e67663b2f41d63472e811b
+  revision: a2c3e3ae1e465a7da1a69b1ede2f9b61ce270ad1
   branch: main
   specs:
     panda-core (0.14.4)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: cb5bc1c5dd8668c2ff4c976db01146554df446ab
+  revision: f8d20d09d578b1bdf1cafb96cd3b740c392c51ad
   branch: main
   specs:
     panda-editor (0.8.3)
@@ -259,8 +259,9 @@ GEM
     invisible_captcha (2.3.0)
       rails (>= 5.2)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.17.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.18.1)

--- a/spec/system/panda/cms/admin/redirects/redirects_management_spec.rb
+++ b/spec/system/panda/cms/admin/redirects/redirects_management_spec.rb
@@ -162,12 +162,6 @@ RSpec.describe "Redirects Management", type: :system do
   end
 
   describe "deleting a redirect" do
-    it "has delete links on the index page" do
-      visit "/admin/cms/redirects"
-
-      expect(page).to have_css("a[data-turbo-method='delete']", wait: 10)
-    end
-
     it "can delete a redirect" do
       redirect_to_delete = Panda::CMS::Redirect.create!(
         origin_path: "/delete-me",


### PR DESCRIPTION
## Summary
- Remove test that expected delete links (`a[data-turbo-method='delete']`) on the redirects index page — these were intentionally moved to the edit page in 3a0b86b
- The existing "has a delete button" test under "editing a redirect" already covers the delete link on the edit page
- Update `panda-editor` and `irb` to latest versions

## Test plan
- [x] All 18 redirects management tests pass locally
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)