### PR TITLE
Allow admin deletion of attached blobs in Files page

### DIFF
--- a/app/controllers/panda/cms/admin/files_controller.rb
+++ b/app/controllers/panda/cms/admin/files_controller.rb
@@ -131,7 +131,8 @@ module Panda
         end
 
         def destroy
-          @blob.attachments.destroy_all
+          ActiveStorage::Attachment.where(blob_id: @blob.id).delete_all
+          Panda::Core::FileCategorization.where(blob_id: @blob.id).delete_all
           @blob.purge
           redirect_to admin_cms_files_path, notice: "File was successfully deleted.", status: :see_other
         end

--- a/app/controllers/panda/cms/admin/files_controller.rb
+++ b/app/controllers/panda/cms/admin/files_controller.rb
@@ -131,26 +131,9 @@ module Panda
         end
 
         def destroy
-          if @blob.attachments.exists?
-            @file_categories = Panda::Core::FileCategory.ordered
-            locals = {file: @blob, file_categories: @file_categories, error: "File cannot be deleted because it is still in use."}
-            respond_to do |format|
-              format.turbo_stream do
-                render turbo_stream: turbo_stream.update(
-                  "file-gallery-slideover-content",
-                  partial: "file_details",
-                  locals: locals
-                )
-              end
-              format.html do
-                redirect_to admin_cms_files_path, alert: "File cannot be deleted because it is still in use.", status: :see_other
-              end
-            end
-          else
-            Panda::Core::FileCategorization.where(blob_id: @blob.id).destroy_all
-            @blob.purge
-            redirect_to admin_cms_files_path, notice: "File was successfully deleted.", status: :see_other
-          end
+          @blob.attachments.destroy_all
+          @blob.purge
+          redirect_to admin_cms_files_path, notice: "File was successfully deleted.", status: :see_other
         end
 
         private


### PR DESCRIPTION
## Summary
- Remove the "in use" block that prevented admin deletion of blobs with active attachments
- Destroy attachments before purging — admin already confirms via `turbo_confirm` dialog
- Fixes orphaned avatar blobs that couldn't be deleted after replacement

## Test plan
- [x] All 866 panda-cms specs pass (1 pre-existing flaky failure in page slug test)
- [x] 3 new destroy specs: basic deletion, attached blob deletion, categorization cleanup
- [ ] Delete an "in use" blob on staging → verify it's removed from DB and storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)