### PR TITLE
Fix dropdown menu clipped in widget header

### DIFF
--- a/app/views/panda/cms/admin/_widget_header.html.erb
+++ b/app/views/panda/cms/admin/_widget_header.html.erb
@@ -1,5 +1,5 @@
-<div class="flex items-center justify-between text-sm font-medium px-4 py-3 text-gray-500 truncate border-b border-gray-200">
-  <h3 class="text-sm font-medium text-gray-500"><%= title %></h3>
+<div class="flex items-center justify-between text-sm font-medium px-4 py-3 text-gray-500 border-b border-gray-200">
+  <h3 class="text-sm font-medium text-gray-500 truncate"><%= title %></h3>
   <% if local_assigns[:period_options].present? %>
     <% selected_label = period_options.find { |_, v| v.to_s == local_assigns[:selected_period].to_s }&.first || period_options.first&.first %>
     <%= render Panda::Core::Admin::DropdownComponent.new do |dropdown| %>


### PR DESCRIPTION
## Summary

- Move `truncate` class from the widget header container `div` to the `h3` title element
- The `truncate` class applies `overflow: hidden` which clips absolutely-positioned dropdown menus regardless of `z-index`
- Affects all dashboard analytics widgets (Analytics, Top Referrers, Page Views Chart) that use the shared `_widget_header` partial

## Test plan

- [ ] Open Dashboard with analytics widgets visible
- [ ] Click the period dropdown (e.g., "Last 30 days") on any widget
- [ ] Verify the dropdown menu is fully visible and not clipped by surrounding content
- [ ] Verify long widget titles still truncate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)