### PR TITLE
Fix test pollution: replace reset_config! with targeted restore

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 8ee9cfb03beb68cca6388676db43ae2e26dc7b03
+  revision: 67329a8a2d53dd0f86080f7ab6b2c58fc0723533
   branch: main
   specs:
     panda-core (0.14.4)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Panda::CMS::Engine.routes.draw do
   ### PUBLIC ROUTES ###
 
   # Sitemap
-  get "sitemap", to: "sitemaps#index", as: :sitemap, defaults: {format: :xml}, constraints: { format: :xml }
+  get "sitemap", to: "sitemaps#index", as: :sitemap, defaults: {format: :xml}, constraints: {format: :xml}
 
   # Authentication routes are now handled by Panda::Core
 

--- a/spec/requests/panda/cms/admin/block_contents_controller_spec.rb
+++ b/spec/requests/panda/cms/admin/block_contents_controller_spec.rb
@@ -71,13 +71,14 @@ RSpec.describe "Admin Block Contents", type: :request do
     let(:text_block) { panda_cms_blocks(:plain_text_block) }
 
     before do
+      @original_authorization_policy = Panda::Core.config.authorization_policy
       Panda::Core.config.authorization_policy = ->(_user, action, _resource) {
         action == :access_admin
       }
     end
 
     after do
-      Panda::Core.reset_config!
+      Panda::Core.config.authorization_policy = @original_authorization_policy
     end
 
     it "checks permission for code blocks" do


### PR DESCRIPTION
## Summary

- Fix dashboard navigation test failing intermittently on CI due to test ordering
- Replace `Panda::Core.reset_config!` with save/restore of only `authorization_policy`
- Fix pre-existing StandardRB whitespace issue in sitemap route constraint

### Root cause

The `block_contents_controller_spec` called `Panda::Core.reset_config!` in its `after` block, which destroyed **all** configuration set during engine boot — including `admin_navigation_items` registered by panda-cms's `panda.cms.configure_core` initializer. When this spec ran before the dashboard spec (random test ordering with seed 51038), panda-core's default navigation (simple links without expandable groups) was used instead of panda-cms's full navigation, causing:

```
expected to find css "a[href=\"/admin/cms/pages\"]" but there were no matches
```

The CI failure screenshot confirmed the sidebar showed only Dashboard/Content/My Profile links (panda-core defaults) instead of the full CMS navigation with expandable Content, Website, Tools, and Settings groups.

### Fix

Save `authorization_policy` before modifying it and restore only that specific setting afterward, leaving all other configuration (navigation items, dashboard widgets, breadcrumbs, etc.) intact.

## Test plan

- [x] `bundle exec rspec spec/requests/panda/cms/admin/block_contents_controller_spec.rb spec/system/panda/cms/admin/dashboard_spec.rb` — 15/15 pass
- [x] All pre-commit hooks pass (brakeman, bundle-audit, erblint, standardrb, zeitwerk)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)