### PR TITLE
Add form block type with FormComponent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 67329a8a2d53dd0f86080f7ab6b2c58fc0723533
+  revision: 0dcce68780e5bf713387c73de5e8224b1dfba623
   branch: main
   specs:
     panda-core (0.14.4)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: 20afa65b2d30792a01c8fdb1ad2070787620dfeb
+  revision: 0320ef301946755374e7cb9517810e69d6fff2a9
   branch: main
   specs:
     panda-editor (0.8.3)

--- a/app/components/panda/cms/form_component.html.erb
+++ b/app/components/panda/cms/form_component.html.erb
@@ -1,0 +1,51 @@
+<% if @editable_state %>
+  <div data-controller="inline-form-selector"
+       data-inline-form-selector-page-id-value="<%= Panda::CMS::Current.page.id %>"
+       data-inline-form-selector-block-content-id-value="<%= @block_content_id %>"
+       class="panda-cms-form-selector border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+    <!-- Header -->
+    <div class="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2 flex items-center justify-between">
+      <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Form Block</span>
+      <div class="flex items-center gap-2">
+        <select data-inline-form-selector-target="formSelect"
+                data-action="change->inline-form-selector#previewForm"
+                class="text-sm border-gray-300 rounded-md shadow-sm focus:border-primary focus:ring-primary dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
+          <option value="">-- No form selected --</option>
+          <% @available_forms.each do |available_form| %>
+            <option value="<%= available_form.id %>"
+                    <%= "selected" if @form_id == available_form.id.to_s %>
+                    data-field-count="<%= available_form.form_fields.count %>"
+                    data-status="<%= available_form.status %>">
+              <%= available_form.name %>
+              (<%= available_form.form_fields.count %> fields)
+              <% unless available_form.accepting_submissions? %>
+                - not accepting submissions
+              <% end %>
+            </option>
+          <% end %>
+        </select>
+        <button type="button"
+                data-action="click->inline-form-selector#saveSelection"
+                class="px-3 py-1 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-md">
+          Save
+        </button>
+      </div>
+      <div data-inline-form-selector-target="saveMessage" class="hidden"></div>
+    </div>
+
+    <!-- Preview area -->
+    <div data-inline-form-selector-target="previewArea" class="p-4">
+      <% if @form %>
+        <div class="opacity-60 pointer-events-none">
+          <%= helpers.panda_cms_render_form(@form) %>
+        </div>
+      <% else %>
+        <div class="text-center py-8 text-gray-400">
+          <p class="text-sm">No form selected. Choose a form from the dropdown above.</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% elsif @form&.accepting_submissions? %>
+  <%= helpers.panda_cms_render_form(@form) %>
+<% end %>

--- a/app/components/panda/cms/form_component.html.erb
+++ b/app/components/panda/cms/form_component.html.erb
@@ -12,12 +12,13 @@
                 class="text-sm border-gray-300 rounded-md shadow-sm focus:border-primary focus:ring-primary dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
           <option value="">-- No form selected --</option>
           <% @available_forms.each do |available_form| %>
+            <% field_count = available_form.form_fields.size %>
             <option value="<%= available_form.id %>"
                     <%= "selected" if @form_id == available_form.id.to_s %>
-                    data-field-count="<%= available_form.form_fields.count %>"
+                    data-field-count="<%= field_count %>"
                     data-status="<%= available_form.status %>">
               <%= available_form.name %>
-              (<%= available_form.form_fields.count %> fields)
+              (<%= field_count %> fields)
               <% unless available_form.accepting_submissions? %>
                 - not accepting submissions
               <% end %>

--- a/app/components/panda/cms/form_component.rb
+++ b/app/components/panda/cms/form_component.rb
@@ -30,13 +30,16 @@ module Panda
         @editable_state = component_is_editable?
 
         block = find_block
-        return false if block.nil?
+        if block.nil?
+          @editable_state = false
+          return
+        end
 
         @block_content_obj = find_block_content(block)
         @form_id = @block_content_obj&.content.to_s.presence
         @block_content_id = @block_content_obj&.id
         @form = Panda::CMS::Form.find_by(id: @form_id) if @form_id
-        @available_forms = Panda::CMS::Form.order(:name) if @editable_state
+        @available_forms = Panda::CMS::Form.includes(:form_fields).order(:name) if @editable_state
       end
 
       def find_block

--- a/app/components/panda/cms/form_component.rb
+++ b/app/components/panda/cms/form_component.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    # Form component for embedding CMS forms into page templates
+    # Admins select which form to display via a dropdown in the page editor
+    # @param key [Symbol] The key to use for the form component
+    # @param editable [Boolean] If the form is editable or not (defaults to true)
+    class FormComponent < Panda::Core::Base
+      KIND = "form"
+
+      attr_reader :key, :editable
+
+      def initialize(key:, editable: true, **attrs)
+        @key = key
+        @editable = editable
+        super(**attrs)
+      end
+
+      def before_render
+        prepare_content
+      end
+
+      private
+
+      attr_accessor :block_content_obj, :form_id, :form, :available_forms,
+        :block_content_id, :editable_state
+
+      def prepare_content
+        @editable_state = component_is_editable?
+
+        block = find_block
+        return false if block.nil?
+
+        @block_content_obj = find_block_content(block)
+        @form_id = @block_content_obj&.content.to_s.presence
+        @block_content_id = @block_content_obj&.id
+        @form = Panda::CMS::Form.find_by(id: @form_id) if @form_id
+        @available_forms = Panda::CMS::Form.order(:name) if @editable_state
+      end
+
+      def find_block
+        Panda::CMS::Block.find_by(
+          kind: KIND,
+          key: @key,
+          panda_cms_template_id: Current.page.panda_cms_template_id
+        )
+      end
+
+      def find_block_content(block)
+        block.block_contents.find_by(panda_cms_page_id: Current.page.id)
+      end
+
+      def component_is_editable?
+        @editable && is_embedded?
+      end
+
+      def is_embedded?
+        page_id = Current.page&.id.to_s
+
+        # Check for session-based editing (preferred, more secure)
+        editing_page_id = view_context.session[:panda_cms_editing_page_id]
+        editing_expires_at = view_context.session[:panda_cms_editing_expires_at]
+
+        session_valid = editing_page_id == page_id &&
+          editing_expires_at.present? &&
+          Time.parse(editing_expires_at) > Time.current
+
+        # Fall back to URL param for backwards compatibility (will be removed in future)
+        embed_id = view_context.params[:embed_id].to_s
+        url_param_valid = embed_id.present? && embed_id == page_id
+
+        session_valid || url_param_valid
+      end
+
+      public
+
+      # Forms contain CSRF tokens and spam-protection timestamps that are
+      # generated per-request, so caching their output would break submissions.
+      def should_cache?
+        false
+      end
+    end
+  end
+end

--- a/app/helpers/panda/cms/forms_helper.rb
+++ b/app/helpers/panda/cms/forms_helper.rb
@@ -34,7 +34,7 @@ module Panda
       #   <% end %>
       def panda_cms_protected_form(form, options = {}, &block)
         default_options = {
-          url: "/forms/#{form.id}",
+          url: "/_forms/#{form.id}",
           method: :post,
           data: {turbo: false}
         }
@@ -78,17 +78,13 @@ module Panda
         submit_class = options.delete(:submit_class) || "inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
 
         panda_cms_protected_form(form, options.merge(class: wrapper_class)) do |f|
-          content = ActiveSupport::SafeBuffer.new
-
           form.form_fields.active.ordered.each do |field|
-            content << render_form_field(field)
+            concat render_form_field(field)
           end
 
-          content << content_tag(:div, class: "mt-6") do
+          concat content_tag(:div, class: "mt-6") {
             content_tag(:button, submit_text, type: "submit", class: submit_class)
-          end
-
-          content
+          }
         end
       end
 

--- a/app/helpers/panda/cms/forms_helper.rb
+++ b/app/helpers/panda/cms/forms_helper.rb
@@ -82,9 +82,9 @@ module Panda
             concat render_form_field(field)
           end
 
-          concat content_tag(:div, class: "mt-6") {
+          concat(content_tag(:div, class: "mt-6") do
             content_tag(:button, submit_text, type: "submit", class: submit_class)
-          }
+          end)
         end
       end
 

--- a/app/javascript/panda/cms/controllers/inline_form_selector_controller.js
+++ b/app/javascript/panda/cms/controllers/inline_form_selector_controller.js
@@ -1,0 +1,83 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["formSelect", "previewArea", "saveMessage"]
+  static values = {
+    pageId: String,
+    blockContentId: String
+  }
+
+  connect() {
+    // Form selector is ready
+  }
+
+  previewForm() {
+    const selectedOption = this.formSelectTarget.selectedOptions[0]
+    if (!selectedOption || !selectedOption.value) {
+      this.previewAreaTarget.innerHTML = `
+        <div class="text-center py-8 text-gray-400">
+          <p class="text-sm">No form selected. Choose a form from the dropdown above.</p>
+        </div>
+      `
+      return
+    }
+
+    const formName = selectedOption.text.trim()
+    this.previewAreaTarget.innerHTML = `
+      <div class="text-center py-8 text-gray-500">
+        <p class="text-sm font-medium">${formName}</p>
+        <p class="text-xs mt-1">Save and reload to see the full form preview.</p>
+      </div>
+    `
+  }
+
+  async saveSelection() {
+    const formId = this.formSelectTarget.value
+    const pageId = this.pageIdValue
+    const blockContentId = this.blockContentIdValue
+
+    try {
+      const response = await fetch(`/admin/cms/pages/${pageId}/block_contents/${blockContentId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        },
+        body: JSON.stringify({
+          content: formId
+        })
+      })
+
+      if (response.ok) {
+        this.showSaveMessage('Form selection saved!', 'success')
+
+        setTimeout(() => {
+          window.location.reload()
+        }, 1000)
+      } else {
+        this.showSaveMessage('Error saving form selection', 'error')
+      }
+    } catch (error) {
+      console.error('Error saving form selection:', error)
+      this.showSaveMessage('Error saving form selection', 'error')
+    }
+  }
+
+  showSaveMessage(message, type) {
+    const messageEl = this.saveMessageTarget
+    messageEl.textContent = message
+    messageEl.classList.remove('hidden')
+
+    if (type === 'success') {
+      messageEl.className = 'ml-2 px-2 py-1 rounded text-xs bg-green-50 text-green-800 border border-green-200'
+    } else {
+      messageEl.className = 'ml-2 px-2 py-1 rounded text-xs bg-red-50 text-red-800 border border-red-200'
+    }
+
+    setTimeout(() => {
+      if (type !== 'success') {
+        messageEl.classList.add('hidden')
+      }
+    }, 3000)
+  }
+}

--- a/app/javascript/panda/cms/controllers/inline_form_selector_controller.js
+++ b/app/javascript/panda/cms/controllers/inline_form_selector_controller.js
@@ -13,22 +13,30 @@ export default class extends Controller {
 
   previewForm() {
     const selectedOption = this.formSelectTarget.selectedOptions[0]
+    this.previewAreaTarget.replaceChildren()
+
     if (!selectedOption || !selectedOption.value) {
-      this.previewAreaTarget.innerHTML = `
-        <div class="text-center py-8 text-gray-400">
-          <p class="text-sm">No form selected. Choose a form from the dropdown above.</p>
-        </div>
-      `
+      const wrapper = document.createElement('div')
+      wrapper.className = 'text-center py-8 text-gray-400'
+      const msg = document.createElement('p')
+      msg.className = 'text-sm'
+      msg.textContent = 'No form selected. Choose a form from the dropdown above.'
+      wrapper.appendChild(msg)
+      this.previewAreaTarget.appendChild(wrapper)
       return
     }
 
-    const formName = selectedOption.text.trim()
-    this.previewAreaTarget.innerHTML = `
-      <div class="text-center py-8 text-gray-500">
-        <p class="text-sm font-medium">${formName}</p>
-        <p class="text-xs mt-1">Save and reload to see the full form preview.</p>
-      </div>
-    `
+    const wrapper = document.createElement('div')
+    wrapper.className = 'text-center py-8 text-gray-500'
+    const nameEl = document.createElement('p')
+    nameEl.className = 'text-sm font-medium'
+    nameEl.textContent = selectedOption.text.trim()
+    const hintEl = document.createElement('p')
+    hintEl.className = 'text-xs mt-1'
+    hintEl.textContent = 'Save and reload to see the full form preview.'
+    wrapper.appendChild(nameEl)
+    wrapper.appendChild(hintEl)
+    this.previewAreaTarget.appendChild(wrapper)
   }
 
   async saveSelection() {
@@ -44,7 +52,7 @@ export default class extends Controller {
           'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
         },
         body: JSON.stringify({
-          content: formId
+          content: formId || "{}"
         })
       })
 

--- a/app/models/panda/cms/block.rb
+++ b/app/models/panda/cms/block.rb
@@ -22,7 +22,8 @@ module Panda
         file: "file",
         code: "code",
         iframe: "iframe",
-        quote: "quote"
+        quote: "quote",
+        form: "form"
       }
     end
   end

--- a/spec/components/panda/cms/form_component_spec.rb
+++ b/spec/components/panda/cms/form_component_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Panda::CMS::FormComponent, type: :component do
     context "when the referenced form has been deleted (stale ID)" do
       before do
         block_content = panda_cms_block_contents(:about_page_contact_form)
-        block_content.update_column(:content, "\"00000000-0000-0000-0000-000000000000\"")
+        block_content.update_column(:content, "00000000-0000-0000-0000-000000000000")
       end
 
       it "renders nothing" do

--- a/spec/components/panda/cms/form_component_spec.rb
+++ b/spec/components/panda/cms/form_component_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::FormComponent, type: :component do
+  before do
+    vc_test_controller.class.helper Panda::CMS::FormsHelper
+  end
+
+  describe "constants" do
+    it "has KIND set to 'form'" do
+      expect(described_class::KIND).to eq("form")
+    end
+  end
+
+  describe "initialization" do
+    it "accepts key property" do
+      component = described_class.new(key: :contact_form, editable: false)
+      expect(component).to be_a(described_class)
+    end
+
+    it "defaults editable to true" do
+      component = described_class.new(key: :contact_form)
+      expect(component.editable).to be true
+    end
+  end
+
+  describe "rendering with fixtures" do
+    let(:page) { panda_cms_pages(:about_page) }
+    let(:template) { page.template }
+    let(:form) { panda_cms_forms(:contact_form) }
+
+    before do
+      allow(Panda::CMS::Current).to receive(:page).and_return(page)
+      allow(Panda::CMS::Current).to receive(:user).and_return(nil)
+    end
+
+    context "when a valid form ID is stored" do
+      it "renders the form" do
+        component = described_class.new(key: :contact_form, editable: false)
+        output = render_inline(component)
+        expect(output.css("form").length).to be >= 1
+      end
+
+      it "renders the form with correct submission URL" do
+        component = described_class.new(key: :contact_form, editable: false)
+        output = render_inline(component)
+        form_el = output.css("form").first
+        expect(form_el["action"]).to include("/_forms/")
+      end
+
+      it "includes spam protection fields" do
+        component = described_class.new(key: :contact_form, editable: false)
+        output = render_inline(component)
+        expect(output.css("input[name='_form_timestamp']")).to be_present
+        expect(output.css("input[name='spinner']")).to be_present
+      end
+    end
+
+    context "when no form is selected (empty content)" do
+      before do
+        block_content = panda_cms_block_contents(:about_page_contact_form)
+        block_content.update_column(:content, "{}")
+      end
+
+      it "renders nothing" do
+        component = described_class.new(key: :contact_form, editable: false)
+        output = render_inline(component)
+        expect(output.css("form")).to be_empty
+        expect(output.text.strip).to eq("")
+      end
+    end
+
+    context "when the referenced form has been deleted (stale ID)" do
+      before do
+        block_content = panda_cms_block_contents(:about_page_contact_form)
+        block_content.update_column(:content, "\"00000000-0000-0000-0000-000000000000\"")
+      end
+
+      it "renders nothing" do
+        component = described_class.new(key: :contact_form, editable: false)
+        output = render_inline(component)
+        expect(output.css("form")).to be_empty
+        expect(output.text.strip).to eq("")
+      end
+    end
+
+    context "when the form is not accepting submissions" do
+      before do
+        form.update_column(:status, "draft")
+      end
+
+      it "renders nothing" do
+        component = described_class.new(key: :contact_form, editable: false)
+        output = render_inline(component)
+        expect(output.css("form")).to be_empty
+        expect(output.text.strip).to eq("")
+      end
+    end
+
+    context "when no block exists for the key" do
+      it "renders nothing" do
+        component = described_class.new(key: :nonexistent_form, editable: false)
+        output = render_inline(component)
+        expect(output.css("form")).to be_empty
+        expect(output.text.strip).to eq("")
+      end
+    end
+  end
+end

--- a/spec/fixtures/panda_cms_block_contents.yml
+++ b/spec/fixtures/panda_cms_block_contents.yml
@@ -158,3 +158,11 @@ custom_page_content:
   cached_content: "<p>This is the main content area for the custom page.</p>"
   created_at: 2025-01-01 00:00:00
   updated_at: 2025-01-01 00:00:00
+
+# Form block content linking about page to the contact form
+about_page_contact_form:
+  block: contact_form_block
+  page: about_page
+  content: "a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d"
+  created_at: 2025-01-01 00:00:00
+  updated_at: 2025-01-01 00:00:00

--- a/spec/fixtures/panda_cms_blocks.yml
+++ b/spec/fixtures/panda_cms_blocks.yml
@@ -50,3 +50,12 @@ content_block:
   template: different_page_template
   created_at: 2025-01-01 00:00:00
   updated_at: 2025-01-01 00:00:00
+
+# Form block for the page template
+contact_form_block:
+  name: "Contact Form"
+  key: "contact_form"
+  kind: "form"
+  template: page_template
+  created_at: 2025-01-01 00:00:00
+  updated_at: 2025-01-01 00:00:00


### PR DESCRIPTION
## Summary
- Adds a new `form` block kind that lets admins select which form to embed on a page via a dropdown in the editor
- Creates `FormComponent` (ViewComponent) with edit and display modes
- Connects the existing form system (Form, FormField, FormSubmission) to the block/template system, replacing hardcoded `Form.find_by` lookups in templates
- Fixes form submission URL from `/forms/` to `/_forms/` in FormsHelper
- Fixes `panda_cms_render_form` to use `concat` for field rendering

## Context
neurobetter main already references `Panda::CMS::FormComponent` in its contact and ask_a_counsellor layouts, causing CI failures until this is merged.

## Test plan
- [ ] FormComponent specs pass (included in this PR)
- [ ] neurobetter system tests for Contact and Ask A Counsellor pages pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)