### PR TITLE
Add parent inference from path hierarchy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: 0320ef301946755374e7cb9517810e69d6fff2a9
+  revision: c535636ec7638ab5e184c9b1e18ff6985c9fedec
   branch: main
   specs:
     panda-editor (0.8.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: c535636ec7638ab5e184c9b1e18ff6985c9fedec
+  revision: 0320ef301946755374e7cb9517810e69d6fff2a9
   branch: main
   specs:
     panda-editor (0.8.3)

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -231,6 +231,8 @@ module Panda
         return if path.blank? || path == "/"
 
         expected_parent_path = File.dirname(path) # e.g. "/advice-hub/foo" => "/advice-hub"
+        return if parent&.path == expected_parent_path
+
         expected_parent = self.class.find_by(path: expected_parent_path)
         return unless expected_parent
 

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -85,6 +85,7 @@ module Panda
 
       # Callbacks
       before_validation :normalize_path
+      before_validation :infer_parent_from_path
       after_save :handle_after_save
       before_save :update_cached_last_updated_at
 
@@ -224,6 +225,16 @@ module Panda
       def normalize_path
         return if path.blank? || path == "/"
         self.path = path.chomp("/") while path.end_with?("/") && path.length > 1
+      end
+
+      def infer_parent_from_path
+        return if path.blank? || path == "/"
+
+        expected_parent_path = File.dirname(path) # e.g. "/advice-hub/foo" => "/advice-hub"
+        expected_parent = self.class.find_by(path: expected_parent_path)
+        return unless expected_parent
+
+        self.parent = expected_parent if parent_id.nil? || parent_id != expected_parent.id
       end
 
       def character_state_for(value, limit)

--- a/spec/models/panda/cms/page_spec.rb
+++ b/spec/models/panda/cms/page_spec.rb
@@ -408,11 +408,13 @@ RSpec.describe Panda::CMS::Page, type: :model do
 
     describe "#infer_parent_from_path" do
       it "skips for root page" do
-        homepage = Panda::CMS::Page.find_by(path: "/")
-        if homepage
-          homepage.valid?
-          expect(homepage.parent_id).to be_nil
+        homepage = Panda::CMS::Page.find_or_create_by!(path: "/") do |p|
+          p.title = "Home"
+          p.template = test_template
+          p.status = "active"
         end
+        homepage.valid?
+        expect(homepage.parent_id).to be_nil
       end
 
       it "infers parent from path when parent_id is nil" do
@@ -429,7 +431,13 @@ RSpec.describe Panda::CMS::Page, type: :model do
 
       it "corrects wrong parent_id based on path hierarchy" do
         test_root # ensure correct parent exists before validation
-        wrong_parent = Panda::CMS::Page.find_by(path: "/")
+        wrong_parent = Panda::CMS::Page.create!(
+          title: "Wrong Parent",
+          path: "/callback-test/wrong-section",
+          parent: test_root,
+          template: test_template,
+          status: "active"
+        )
         page = Panda::CMS::Page.new(
           title: "Misparented Page",
           path: "/callback-test/misparented",


### PR DESCRIPTION
## Summary

- Add `before_validation :infer_parent_from_path` callback to `Panda::CMS::Page`
- Auto-infers parent page from path hierarchy using `File.dirname` (e.g. `/advice-hub/foo` → parent is `/advice-hub`)
- Corrects wrong `parent_id` when it doesn't match the path hierarchy
- Skips for root page (`/`) and when no matching parent page exists
- Add 6 test cases covering: nil parent, wrong parent, deep nesting, correct parent unchanged, root skip, no parent found

## Context

Pages created programmatically (MCP, API, bulk scripts) could end up with wrong `parent_id` because the model treated `path` and `parent_id` as independent fields. This caused pages to appear at the wrong level in the admin tree and break auto-generated menus.

## Test plan

- [x] All 62 page model specs pass (0 failures)
- [x] StandardRB clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)