### PR TITLE
Add pinned pages support for auto-menus

### DIFF
--- a/app/controllers/panda/cms/admin/menus_controller.rb
+++ b/app/controllers/panda/cms/admin/menus_controller.rb
@@ -5,7 +5,7 @@ module Panda
     module Admin
       class MenusController < ::Panda::CMS::Admin::BaseController
         before_action :set_initial_breadcrumb, only: %i[index new edit]
-        before_action :set_menu, only: %i[edit update destroy]
+        before_action :set_menu, only: %i[edit update destroy toggle_pin]
 
         # Lists all menus which can be managed by the administrator
         # @type GET
@@ -52,6 +52,18 @@ module Panda
         def destroy
           @menu.destroy
           redirect_to admin_cms_menus_path, notice: "Menu was successfully deleted."
+        end
+
+        # @type POST
+        def toggle_pin
+          page_id = params[:page_id].to_s
+          if @menu.page_pinned?(page_id)
+            @menu.unpin_page(page_id)
+          else
+            @menu.pin_page(page_id)
+          end
+          @menu.save!
+          redirect_to edit_admin_cms_menu_path(@menu), notice: "Pin state updated."
         end
 
         private

--- a/app/views/panda/cms/admin/menus/edit.html.erb
+++ b/app/views/panda/cms/admin/menus/edit.html.erb
@@ -53,6 +53,14 @@
             <% end %>
             <% table.column("Page") { |menu_item| menu_item.page&.title } %>
             <% table.column("Path") { |menu_item| menu_item.page&.path } %>
+            <% table.column("Pinned", width: "5rem") do |menu_item| %>
+              <% if menu_item.depth > 0 && menu_item.page.present? %>
+                <% pinned = @menu.page_pinned?(menu_item.page.id) %>
+                <%= button_to toggle_pin_admin_cms_menu_path(@menu, page_id: menu_item.page.id), method: :post, class: "inline-flex items-center justify-center" do %>
+                  <i class="fa-solid fa-thumbtack <%= pinned ? 'text-blue-500' : 'text-gray-300 hover:text-gray-400' %>"></i>
+                <% end %>
+              <% end %>
+            <% end %>
           <% end %>
         <% else %>
           <p class="text-sm text-gray-500 dark:text-gray-400">No menu items generated yet. Select a start page and save to generate menu items.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Panda::CMS::Engine.routes.draw do
       resources :files
       resources :forms
       post "link_metadata", to: "link_metadata#create", as: :link_metadata
-      resources :menus
+      resources :menus do
+        post :toggle_pin, on: :member
+      end
       resources :pages do
         resources :block_contents, only: %i[update]
       end

--- a/db/migrate/20260211000000_add_pinned_page_ids_to_panda_cms_menus.rb
+++ b/db/migrate/20260211000000_add_pinned_page_ids_to_panda_cms_menus.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPinnedPageIdsToPandaCMSMenus < ActiveRecord::Migration[7.1]
+  def change
+    add_column :panda_cms_menus, :pinned_page_ids, :jsonb, default: [], null: false
+  end
+end

--- a/db/migrate/20260211000000_add_pinned_page_ids_to_panda_cms_menus.rb
+++ b/db/migrate/20260211000000_add_pinned_page_ids_to_panda_cms_menus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPinnedPageIdsToPandaCMSMenus < ActiveRecord::Migration[7.1]
+class AddPinnedPageIdsToPandaCMSMenus < ActiveRecord::Migration[8.1]
   def change
     add_column :panda_cms_menus, :pinned_page_ids, :jsonb, default: [], null: false
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_07_112500) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_11_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -173,6 +173,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_07_112500) do
     t.enum "kind", default: "static", null: false, enum_type: "panda_cms_menu_kind"
     t.string "name", null: false
     t.enum "ordering", default: "default", null: false, enum_type: "panda_cms_menu_ordering"
+    t.jsonb "pinned_page_ids", default: [], null: false
     t.uuid "start_page_id"
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_panda_cms_menus_on_name", unique: true

--- a/spec/fixtures/panda_cms_menus.yml
+++ b/spec/fixtures/panda_cms_menus.yml
@@ -4,6 +4,7 @@ main_menu:
   name: "Main Menu"
   kind: "static"
   ordering: "default"
+  pinned_page_ids: []
   created_at: 2025-01-01 00:00:00
   updated_at: 2025-01-01 00:00:00
 
@@ -11,6 +12,7 @@ footer_menu:
   name: "Footer Menu"
   kind: "static"
   ordering: "default"
+  pinned_page_ids: []
   created_at: 2025-01-01 00:00:00
   updated_at: 2025-01-01 00:00:00
 
@@ -18,6 +20,7 @@ auto_menu:
   name: "Auto Menu"
   kind: "auto"
   ordering: "default"
+  pinned_page_ids: []
   start_page: homepage
   created_at: 2025-01-01 00:00:00
   updated_at: 2025-01-01 00:00:00


### PR DESCRIPTION
## Summary

- Adds a `pinned_page_ids` JSONB column to `panda_cms_menus` so auto-menus can promote specific child pages to the top of the list
- During auto-menu generation, `order_pages` partitions children into pinned (preserving the stored order) and unpinned (using the menu's ordering setting), placing pinned pages first
- Admin UI gains a thumbtack toggle on auto-menu edit pages for pinning/unpinning child pages
- Fixes a pre-existing test failure where `update!(parent:)` didn't reparent pages correctly with awesome_nested_set — now uses `move_to_child_of`

## Changes

| File | What |
|------|------|
| `db/migrate/..._add_pinned_page_ids_to_panda_cms_menus.rb` | New migration adding JSONB column |
| `app/models/panda/cms/menu.rb` | `page_pinned?`, `pin_page`, `unpin_page` helpers; updated `order_pages` to prioritise pinned pages |
| `app/controllers/panda/cms/admin/menus_controller.rb` | `toggle_pin` action |
| `config/routes.rb` | `post :toggle_pin` member route on menus |
| `app/views/panda/cms/admin/menus/edit.html.erb` | Thumbtack column in auto-menu table |
| `spec/models/panda/cms/menu_spec.rb` | 14 new tests for pinning + fix for pre-existing nested menu item test |
| `spec/fixtures/panda_cms_menus.yml` | Added `pinned_page_ids: []` to fixtures |

## Test plan

- [x] All 43 panda-cms specs pass locally (`bundle exec rspec`)
- [ ] CI passes on this branch
- [ ] Manual test: edit an auto-menu in admin, pin a child page, verify it appears first after save
- [ ] Verify pinning survives menu regeneration (change start page and back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>