### PR TITLE
Fix auto menu regeneration and cache busting

### DIFF
--- a/app/models/panda/cms/menu.rb
+++ b/app/models/panda/cms/menu.rb
@@ -35,6 +35,11 @@ module Panda
           menu_item_root = menu_items.create(text: start_page.title, panda_cms_page_id: start_page.id)
           generate_menu_items(parent_menu_item: menu_item_root, parent_page: start_page)
         end
+
+        # Bump updated_at to bust fragment caches that depend on it.
+        # Uses update_column to avoid re-triggering after_save callbacks.
+        update_column(:updated_at, Time.current)
+        clear_menu_cache
       end
 
       def page_pinned?(page_id)


### PR DESCRIPTION
## Summary
- **Auto menu regeneration** now uses ancestor-based lookup (`self_and_ancestors`) to find affected menus, instead of relying on `menu_items` associations which don't exist for newly created pages
- **Cache busting** fixed: `generate_auto_menu_items` now bumps `updated_at` via `update_column` and calls `clear_menu_cache` so fragment caches are properly invalidated
- **Selective triggering**: auto menu regeneration only runs on page create, title change, status change, or path change (not every save)
- **Destroy callbacks**: deleted pages are now removed from auto menus

## Test plan
- [x] All 111 existing specs pass (Page, Menu, PageMenuComponent)
- [x] All pre-commit checks pass (brakeman, standardrb, erblint, zeitwerk, bundle-audit)
- [ ] Verify on staging: create a child page under an existing auto menu — it should appear in the sidebar
- [ ] Verify title changes propagate to the menu
- [ ] Verify changing page status to draft removes it from the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)