### PR TITLE
Replace page/post status enum with visibility-focused values

### DIFF
--- a/app/components/panda/cms/admin/recent_pages_widget_component.rb
+++ b/app/components/panda/cms/admin/recent_pages_widget_component.rb
@@ -48,8 +48,9 @@ module Panda
         # @return [String]
         def status_color(page)
           case page.status
-          when "active" then "bg-green-100 text-green-800"
-          when "draft" then "bg-yellow-100 text-yellow-800"
+          when "published" then "bg-green-100 text-green-800"
+          when "unlisted" then "bg-blue-100 text-blue-800"
+          when "hidden" then "bg-yellow-100 text-yellow-800"
           when "archived" then "bg-gray-100 text-gray-800"
           else "bg-gray-100 text-gray-800"
           end

--- a/app/controllers/panda/cms/admin/posts_controller.rb
+++ b/app/controllers/panda/cms/admin/posts_controller.rb
@@ -84,7 +84,7 @@ module Panda
             Panda::CMS::Post.find(params[:id])
           else
             Panda::CMS::Post.new(
-              status: "active",
+              status: "published",
               published_at: Time.zone.now
             )
           end

--- a/app/controllers/panda/cms/admin/posts_controller.rb
+++ b/app/controllers/panda/cms/admin/posts_controller.rb
@@ -98,7 +98,7 @@ module Panda
           add_breadcrumb "Add Post", new_admin_cms_post_path
 
           post ||= Panda::CMS::Post.new(
-            status: "active",
+            status: "published",
             published_at: Time.zone.now
           )
 

--- a/app/controllers/panda/cms/pages_controller.rb
+++ b/app/controllers/panda/cms/pages_controller.rb
@@ -17,9 +17,9 @@ module Panda
 
       def show
         page = if @overrides&.dig(:page_path_match)
-          Panda::CMS::Page.includes(:template, :block_contents).find_by(path: @overrides[:page_path_match])
+          Panda::CMS::Page.servable.includes(:template, :block_contents).find_by(path: @overrides[:page_path_match])
         else
-          Panda::CMS::Page.includes(:template, :block_contents).find_by(path: "/#{params[:path]}")
+          Panda::CMS::Page.servable.includes(:template, :block_contents).find_by(path: "/#{params[:path]}")
         end
 
         Panda::CMS::Current.page = page || Panda::CMS::Page.find_by(path: "/404")
@@ -27,7 +27,7 @@ module Panda
 
         layout = page&.template&.file_path
 
-        if page.nil? || page.status == "archived" || layout.nil?
+        if page.nil? || layout.nil?
           # Render the default Panda CMS 404 page with public layout
           render "panda/cms/pages/not_found", layout: "panda/cms/public", status: :not_found and return
         end

--- a/app/controllers/panda/cms/posts_controller.rb
+++ b/app/controllers/panda/cms/posts_controller.rb
@@ -6,7 +6,7 @@ module Panda
       # TODO: Change from layout rendering to standard template rendering
       # inside a /panda/cms/posts/... structure in the application
       def index
-        @posts = Panda::CMS::Post.includes(:author).order(published_at: :desc)
+        @posts = Panda::CMS::Post.where(status: :published).includes(:author).order(published_at: :desc)
 
         # HTTP caching: Use the most recent post's updated_at for conditional requests
         # Returns 304 Not Modified if no posts have changed since client's last request
@@ -20,10 +20,10 @@ module Panda
         @post = if params[:year] && params[:month]
           # For date-based URLs
           slug = "/#{params[:year]}/#{params[:month]}/#{params[:slug]}"
-          Panda::CMS::Post.find_by!(slug: slug)
+          Panda::CMS::Post.servable.find_by!(slug: slug)
         else
           # For non-date URLs
-          Panda::CMS::Post.find_by!(slug: "/#{params[:slug]}")
+          Panda::CMS::Post.servable.find_by!(slug: "/#{params[:slug]}")
         end
 
         # HTTP caching: Send ETag and Last-Modified headers for individual posts
@@ -36,7 +36,7 @@ module Panda
       def by_month
         @month = Date.new(params[:year].to_i, params[:month].to_i, 1)
         @posts = Panda::CMS::Post
-          .where(status: :active)
+          .where(status: :published)
           .where("DATE_TRUNC('month', published_at) = ?", @month)
           .includes(:author)
           .ordered

--- a/app/controllers/panda/cms/sitemaps_controller.rb
+++ b/app/controllers/panda/cms/sitemaps_controller.rb
@@ -5,14 +5,14 @@ module Panda
     class SitemapsController < ApplicationController
       def index
         @pages = Panda::CMS::Page
-          .where(status: :active)
+          .in_sitemap
           .where.not(page_type: [:hidden_type, :system])
           .where(seo_index_mode: :visible)
           .order(:lft)
 
         @posts = if Panda::CMS.config.posts[:enabled]
           Panda::CMS::Post
-            .where(status: :active)
+            .in_sitemap
             .where(seo_index_mode: :visible)
             .order(published_at: :desc)
         else

--- a/app/helpers/panda/cms/posts_helper.rb
+++ b/app/helpers/panda/cms/posts_helper.rb
@@ -11,7 +11,7 @@ module Panda
       def posts_months_menu
         Rails.cache.fetch("panda_cms_posts_months_menu", expires_in: 1.hour) do
           Panda::CMS::Post
-            .where(status: :active)
+            .where(status: :published)
             .select(
               Arel.sql("DATE_TRUNC('month', published_at) as month"),
               Arel.sql("COUNT(*) as post_count")

--- a/app/models/panda/cms/menu.rb
+++ b/app/models/panda/cms/menu.rb
@@ -59,7 +59,7 @@ module Panda
       private
 
       def generate_menu_items(parent_menu_item:, parent_page:)
-        children = parent_page.children.where(status: [:active])
+        children = parent_page.children.where(status: :published)
         children = order_pages(children)
 
         children.each do |page|

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -36,19 +36,21 @@ module Panda
       scope :ordered, -> { order(:lft) }
 
       def self.editor_search(query, limit: 5)
-        where(status: :active)
+        where(status: :published)
           .where("title ILIKE :q OR path ILIKE :q", q: "%#{sanitize_sql_like(query)}%")
           .limit(limit)
           .map { |p| {href: p.path, name: p.title, description: p.path} }
       end
 
       enum :status, {
-        active: "active",
-        draft: "draft",
-        pending_review: "pending_review",
+        published: "published",
+        unlisted: "unlisted",
         hidden: "hidden",
         archived: "archived"
       }
+
+      scope :servable, -> { where(status: [:published, :unlisted, :hidden]) }
+      scope :in_sitemap, -> { where(status: [:published, :unlisted]) }
 
       enum :page_type, {
         standard: "standard",

--- a/app/models/panda/cms/post.rb
+++ b/app/models/panda/cms/post.rb
@@ -30,7 +30,7 @@ module Panda
 
       def self.editor_search(query, limit: 5)
         posts_prefix = Panda::CMS.config.posts[:prefix]
-        where(status: :active)
+        where(status: :published)
           .where("title ILIKE :q OR slug ILIKE :q", q: "%#{sanitize_sql_like(query)}%")
           .limit(limit)
           .map { |p| {href: "#{posts_prefix}#{p.slug}", name: p.title, description: "Post"} }
@@ -39,12 +39,14 @@ module Panda
       scope :with_author, -> { includes(:author) }
 
       enum :status, {
-        active: "active",
-        draft: "draft",
-        pending_review: "pending_review",
+        published: "published",
+        unlisted: "unlisted",
         hidden: "hidden",
         archived: "archived"
       }
+
+      scope :servable, -> { where(status: [:published, :unlisted, :hidden]) }
+      scope :in_sitemap, -> { where(status: [:published, :unlisted]) }
 
       enum :seo_index_mode, {
         visible: "visible",

--- a/app/views/panda/cms/admin/pages/edit.html.erb
+++ b/app/views/panda/cms/admin/pages/edit.html.erb
@@ -45,7 +45,7 @@
       } do |f| %>
         <%= f.text_field :title, { data: { page_form_target: "pageTitle" } } %>
         <%= f.text_field :template, value: template.name, readonly: true %>
-        <%= f.select :status, options_for_select([["Active", "active"], ["Draft", "draft"], ["Hidden", "hidden"], ["Archived", "archived"]], selected: page.status) %>
+        <%= f.select :status, options_for_select([["Published", "published"], ["Unlisted", "unlisted"], ["Hidden", "hidden"], ["Archived", "archived"]], selected: page.status) %>
         <% if page.page_type.in?(["system", "posts"]) %>
           <%= f.text_field :page_type, value: page.page_type.humanize, readonly: true %>
         <% else %>

--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -17,7 +17,7 @@
       </div>
       <%= f.select :author_id, Panda::Core::User.admins.map { |u| [u.name, u.id] } %>
       <%= f.datetime_field :published_at %>
-      <%= f.select :status, options_for_select([["Active", "active"], ["Draft", "draft"], ["Hidden", "hidden"], ["Archived", "archived"]], selected: post.status) %>
+      <%= f.select :status, options_for_select([["Published", "published"], ["Unlisted", "unlisted"], ["Hidden", "hidden"], ["Archived", "archived"]], selected: post.status) %>
     </div>
   <% end %>
 

--- a/db/migrate/20260212000001_change_page_and_post_status_to_visibility.rb
+++ b/db/migrate/20260212000001_change_page_and_post_status_to_visibility.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class ChangePageAndPostStatusToVisibility < ActiveRecord::Migration[7.2]
+  def up
+    # 1. Save current values to a temp string column
+    add_column :panda_cms_pages, :status_tmp, :string
+    add_column :panda_cms_posts, :status_tmp, :string
+    execute "UPDATE panda_cms_pages SET status_tmp = status::text"
+    execute "UPDATE panda_cms_posts SET status_tmp = status::text"
+
+    # 2. Drop the old enum columns and types
+    remove_column :panda_cms_pages, :status
+    remove_column :panda_cms_posts, :status
+    execute "DROP TYPE panda_cms_page_status"
+    execute "DROP TYPE panda_cms_post_status"
+
+    # 3. Create new enum types with only valid values
+    create_enum "panda_cms_page_status", ["published", "unlisted", "hidden", "archived"]
+    create_enum "panda_cms_post_status", ["published", "unlisted", "hidden", "archived"]
+
+    # 4. Add columns back with new enum type
+    add_column :panda_cms_pages, :status, :enum,
+      enum_type: "panda_cms_page_status", default: "published", null: false
+    add_column :panda_cms_posts, :status, :enum,
+      enum_type: "panda_cms_post_status", default: "published", null: false
+
+    # 5. Map old values to new values
+    # active → published, draft/pending_review → published (workflow is now version-level)
+    # hidden stays hidden, archived stays archived
+    execute <<~SQL
+      UPDATE panda_cms_pages SET status = CASE status_tmp
+        WHEN 'active' THEN 'published'
+        WHEN 'draft' THEN 'published'
+        WHEN 'pending_review' THEN 'published'
+        WHEN 'hidden' THEN 'hidden'
+        WHEN 'archived' THEN 'archived'
+        ELSE 'published'
+      END::panda_cms_page_status
+    SQL
+    execute <<~SQL
+      UPDATE panda_cms_posts SET status = CASE status_tmp
+        WHEN 'active' THEN 'published'
+        WHEN 'draft' THEN 'published'
+        WHEN 'pending_review' THEN 'published'
+        WHEN 'hidden' THEN 'hidden'
+        WHEN 'archived' THEN 'archived'
+        ELSE 'published'
+      END::panda_cms_post_status
+    SQL
+
+    # 6. Drop temp columns
+    remove_column :panda_cms_pages, :status_tmp
+    remove_column :panda_cms_posts, :status_tmp
+  end
+
+  def down
+    # 1. Save current values to a temp string column
+    add_column :panda_cms_pages, :status_tmp, :string
+    add_column :panda_cms_posts, :status_tmp, :string
+    execute "UPDATE panda_cms_pages SET status_tmp = status::text"
+    execute "UPDATE panda_cms_posts SET status_tmp = status::text"
+
+    # 2. Drop the new enum columns and types
+    remove_column :panda_cms_pages, :status
+    remove_column :panda_cms_posts, :status
+    execute "DROP TYPE panda_cms_page_status"
+    execute "DROP TYPE panda_cms_post_status"
+
+    # 3. Recreate original enum types
+    create_enum "panda_cms_page_status", ["active", "draft", "pending_review", "hidden", "archived"]
+    create_enum "panda_cms_post_status", ["active", "draft", "pending_review", "hidden", "archived"]
+
+    # 4. Add columns back with original enum type
+    add_column :panda_cms_pages, :status, :enum,
+      enum_type: "panda_cms_page_status", default: "active", null: false
+    add_column :panda_cms_posts, :status, :enum,
+      enum_type: "panda_cms_post_status", default: "active", null: false
+
+    # 5. Map new values back to old values
+    # published → active, unlisted → active (no equivalent in old schema)
+    execute <<~SQL
+      UPDATE panda_cms_pages SET status = CASE status_tmp
+        WHEN 'published' THEN 'active'
+        WHEN 'unlisted' THEN 'active'
+        WHEN 'hidden' THEN 'hidden'
+        WHEN 'archived' THEN 'archived'
+        ELSE 'active'
+      END::panda_cms_page_status
+    SQL
+    execute <<~SQL
+      UPDATE panda_cms_posts SET status = CASE status_tmp
+        WHEN 'published' THEN 'active'
+        WHEN 'unlisted' THEN 'active'
+        WHEN 'hidden' THEN 'hidden'
+        WHEN 'archived' THEN 'archived'
+        ELSE 'active'
+      END::panda_cms_post_status
+    SQL
+
+    # 6. Drop temp columns
+    remove_column :panda_cms_pages, :status_tmp
+    remove_column :panda_cms_posts, :status_tmp
+  end
+end

--- a/db/migrate/20260212000001_change_page_and_post_status_to_visibility.rb
+++ b/db/migrate/20260212000001_change_page_and_post_status_to_visibility.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangePageAndPostStatusToVisibility < ActiveRecord::Migration[7.2]
+class ChangePageAndPostStatusToVisibility < ActiveRecord::Migration[8.1]
   def up
     # 1. Save current values to a temp string column
     add_column :panda_cms_pages, :status_tmp, :string
@@ -23,6 +23,8 @@ class ChangePageAndPostStatusToVisibility < ActiveRecord::Migration[7.2]
       enum_type: "panda_cms_page_status", default: "published", null: false
     add_column :panda_cms_posts, :status, :enum,
       enum_type: "panda_cms_post_status", default: "published", null: false
+    add_index :panda_cms_pages, :status
+    add_index :panda_cms_posts, :status
 
     # 5. Map old values to new values
     # active → published, draft/pending_review → published (workflow is now version-level)
@@ -74,7 +76,9 @@ class ChangePageAndPostStatusToVisibility < ActiveRecord::Migration[7.2]
     add_column :panda_cms_pages, :status, :enum,
       enum_type: "panda_cms_page_status", default: "active", null: false
     add_column :panda_cms_posts, :status, :enum,
-      enum_type: "panda_cms_post_status", default: "active", null: false
+      enum_type: "panda_cms_post_status", default: "draft", null: false
+    add_index :panda_cms_pages, :status
+    add_index :panda_cms_posts, :status
 
     # 5. Map new values back to old values
     # published → active, unlisted → active (no equivalent in old schema)

--- a/lib/panda/cms/bulk_editor.rb
+++ b/lib/panda/cms/bulk_editor.rb
@@ -53,7 +53,7 @@ module Panda
               page = Panda::CMS::Page.create!(
                 path: path,
                 title: page_data["title"],
-                status: page_data["status"] || "active",
+                status: page_data["status"] || "published",
                 page_type: page_data["page_type"] || "standard",
                 template: Panda::CMS::Template.find_by(name: page_data["template"]),
                 parent: Panda::CMS::Page.find_by(path: page_data["parent"]),
@@ -177,7 +177,7 @@ module Panda
               post = Panda::CMS::Post.create!(
                 slug: slug,
                 title: post_data["title"],
-                status: post_data["status"] || "draft",
+                status: post_data["status"] || "published",
                 published_at: post_data["published_at"],
                 user: user,
                 author: author,

--- a/lib/panda/cms/sanctuary_demo.rb
+++ b/lib/panda/cms/sanctuary_demo.rb
@@ -358,7 +358,7 @@ module Panda
         page.assign_attributes(attributes)
         page.panda_cms_template_id = template&.id
         page.parent = parent
-        page.status ||= "active"
+        page.status ||= "published"
         page.save!
         page
       end
@@ -566,42 +566,42 @@ module Panda
           {
             title: "Meet Our Newest Arrival: Baby Panda Mei Mei",
             slug_date: 3.days.ago,
-            status: "active",
+            status: "published",
             content: mei_mei_post_content,
             seo_description: "We're thrilled to announce the birth of Mei Mei, our newest giant panda cub born at The Panda Sanctuary."
           },
           {
             title: "Conservation Success: Wild Panda Population Update",
             slug_date: 1.week.ago,
-            status: "active",
+            status: "published",
             content: conservation_post_content,
             seo_description: "New census data shows encouraging growth in wild giant panda populations, with our conservation efforts playing a key role."
           },
           {
             title: "Behind the Scenes: A Day in the Life of a Panda Keeper",
             slug_date: 2.weeks.ago,
-            status: "active",
+            status: "published",
             content: keeper_post_content,
             seo_description: "Join us as we follow head keeper Sarah through a typical day caring for our pandas at the sanctuary."
           },
           {
             title: "Bamboo Forest Expansion Project Complete",
             slug_date: 3.weeks.ago,
-            status: "active",
+            status: "published",
             content: bamboo_post_content,
             seo_description: "We've completed our bamboo forest expansion, adding 2 hectares of new habitat for our giant pandas."
           },
           {
             title: "Virtual Panda Cams Now Live 24/7",
             slug_date: 1.month.ago,
-            status: "active",
+            status: "published",
             content: webcam_post_content,
             seo_description: "Watch our pandas live anytime with our new 24/7 panda cam streaming service."
           },
           {
             title: "Summer Events Programme Announced",
             slug_date: 5.weeks.ago,
-            status: "draft",
+            status: "hidden",
             content: events_post_content,
             seo_description: "Check out our exciting lineup of summer events including keeper talks, feeding sessions, and family activities."
           }
@@ -615,7 +615,7 @@ module Panda
           post.status = data[:status]
           post.content = data[:content]
           post.cached_content = render_editorjs_content(data[:content])
-          post.published_at = (data[:status] == "active") ? data[:slug_date] : nil
+          post.published_at = (data[:status] == "published") ? data[:slug_date] : nil
           post.seo_description = data[:seo_description]
 
           # Assign demo user as author

--- a/spec/components/panda/cms/admin/recent_pages_widget_component_spec.rb
+++ b/spec/components/panda/cms/admin/recent_pages_widget_component_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe Panda::CMS::Admin::RecentPagesWidgetComponent, type: :component d
   describe "#status_color" do
     let(:component) { described_class.new }
 
-    it "returns green for active pages" do
-      test_page = Panda::CMS::Page.new(status: "active")
+    it "returns green for published pages" do
+      test_page = Panda::CMS::Page.new(status: "published")
       expect(component.status_color(test_page)).to include("green")
     end
 
-    it "returns yellow for draft pages" do
-      test_page = Panda::CMS::Page.new(status: "draft")
+    it "returns yellow for hidden pages" do
+      test_page = Panda::CMS::Page.new(status: "hidden")
       expect(component.status_color(test_page)).to include("yellow")
     end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -20,8 +20,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_175501) do
   create_enum "panda_cms_menu_kind", ["static", "auto"]
   create_enum "panda_cms_menu_ordering", ["default", "alphabetical"]
   create_enum "panda_cms_og_type", ["website", "article", "profile", "video", "book"]
-  create_enum "panda_cms_page_status", ["active", "draft", "hidden", "archived"]
-  create_enum "panda_cms_post_status", ["active", "draft", "hidden", "archived"]
+  create_enum "panda_cms_page_status", ["published", "unlisted", "hidden", "archived"]
+  create_enum "panda_cms_post_status", ["published", "unlisted", "hidden", "archived"]
   create_enum "panda_cms_seo_index_mode", ["visible", "invisible"]
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
@@ -195,7 +195,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_175501) do
     t.enum "seo_index_mode", default: "visible", null: false, enum_type: "panda_cms_seo_index_mode"
     t.string "seo_keywords"
     t.string "seo_title"
-    t.enum "status", default: "active", null: false, enum_type: "panda_cms_page_status"
+    t.enum "status", default: "published", null: false, enum_type: "panda_cms_page_status"
     t.string "title"
     t.datetime "updated_at", null: false
     t.index ["cached_last_updated_at"], name: "index_panda_cms_pages_on_cached_last_updated_at"
@@ -225,7 +225,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_175501) do
     t.string "seo_keywords"
     t.string "seo_title"
     t.string "slug"
-    t.enum "status", default: "draft", null: false, enum_type: "panda_cms_post_status"
+    t.enum "status", default: "published", null: false, enum_type: "panda_cms_post_status"
     t.string "title"
     t.datetime "updated_at", null: false
     t.uuid "user_id"

--- a/spec/fixtures/panda_cms_pages.yml
+++ b/spec/fixtures/panda_cms_pages.yml
@@ -4,7 +4,7 @@ homepage:
   title: "Home"
   path: "/"
   template: homepage_template
-  status: "active"
+  status: "published"
   lft: 1
   rgt: 10
   depth: 0
@@ -16,7 +16,7 @@ about_page:
   path: "/about"
   template: page_template
   parent: homepage
-  status: "active"
+  status: "published"
   lft: 2
   rgt: 5
   depth: 1
@@ -28,7 +28,7 @@ about_team_page:
   path: "/about/team"
   template: page_template
   parent: about_page
-  status: "active"
+  status: "published"
   lft: 3
   rgt: 4
   depth: 2
@@ -40,7 +40,7 @@ services_page:
   path: "/services"
   template: page_template
   parent: homepage
-  status: "active"
+  status: "published"
   lft: 6
   rgt: 7
   depth: 1
@@ -52,7 +52,7 @@ custom_page:
   path: "/custom-page"
   template: different_page_template
   parent: homepage
-  status: "active"
+  status: "published"
   lft: 8
   rgt: 9
   depth: 1

--- a/spec/fixtures/panda_cms_posts.yml
+++ b/spec/fixtures/panda_cms_posts.yml
@@ -3,7 +3,7 @@
 first_post:
   title: "Test Post 1"
   slug: '/<%= Time.current.strftime("%Y/%m") %>/test-post-1'
-  status: "active"
+  status: "published"
   # User references removed - tests must set these programmatically
   published_at: <%= Time.current %>
   content: |-
@@ -33,7 +33,7 @@ first_post:
 second_post:
   title: "Test Post 2"
   slug: '/<%= Time.current.strftime("%Y/%m") %>/test-post-2'
-  status: "draft"
+  status: "hidden"
   # User references removed - tests must set these programmatically
   published_at: null
   content: |-

--- a/spec/helpers/panda/cms/seo_helper_spec.rb
+++ b/spec/helpers/panda/cms/seo_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
       path: "/",
       title: "Root",
       template: test_template,
-      status: "active"
+      status: "published"
     )
     page.save(validate: false)
     page

--- a/spec/lib/panda/cms/bulk_editor_spec.rb
+++ b/spec/lib/panda/cms/bulk_editor_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
     @post1 = Panda::CMS::Post.create!(
       title: "Test Post 1",
       slug: "/#{Time.current.strftime("%Y/%m")}/test-post-1",
-      status: "active",
+      status: "published",
       user: @user,
       published_at: Time.current
     )
@@ -51,7 +51,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
     @post2 = Panda::CMS::Post.create!(
       title: "Test Post 2",
       slug: "/#{Time.current.strftime("%Y/%m")}/test-post-2",
-      status: "draft",
+      status: "hidden",
       user: @user,
       published_at: nil
     )
@@ -83,7 +83,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
         expect(homepage["title"]).to eq("Home")
         expect(homepage["template"]).to eq("Homepage")
         expect(homepage["parent"]).to be_nil
-        expect(homepage["status"]).to eq("active")
+        expect(homepage["status"]).to eq("published")
         expect(homepage["page_type"]).to eq("standard")
       end
 
@@ -164,16 +164,16 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
 
         expect(post).to be_present
         expect(post["title"]).to eq("Test Post 1")
-        expect(post["status"]).to eq("active")
+        expect(post["status"]).to eq("published")
         expect(post["user_email"]).to eq(@user.email)
       end
 
-      it "exports draft posts" do
+      it "exports hidden posts" do
         data = JSON.parse(described_class.export)
         post = data["posts"].find { |p| p["slug"] == @post2.slug }
 
         expect(post).to be_present
-        expect(post["status"]).to eq("draft")
+        expect(post["status"]).to eq("hidden")
       end
 
       it "includes SEO fields for posts when present" do
@@ -257,7 +257,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
           "title" => "New Page",
           "template" => template.name,
           "parent" => "/",
-          "status" => "active",
+          "status" => "published",
           "page_type" => "standard",
           "contents" => {}
         }
@@ -320,7 +320,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
         data["posts"] << {
           "slug" => slug,
           "title" => "New Post",
-          "status" => "draft",
+          "status" => "published",
           "user_email" => @user.email,
           "contents" => {}
         }
@@ -351,7 +351,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
         data["posts"] << {
           "slug" => slug,
           "title" => "Orphan Post",
-          "status" => "draft",
+          "status" => "published",
           "user_email" => "nonexistent@example.com",
           "contents" => {}
         }

--- a/spec/models/panda/cms/menu_spec.rb
+++ b/spec/models/panda/cms/menu_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Panda::CMS::Menu, type: :model do
     end
 
     it "only includes active pages" do
-      child_page.update!(status: :draft)
+      child_page.update!(status: :hidden)
       auto_menu.generate_auto_menu_items
 
       child_item = auto_menu.menu_items.find_by(panda_cms_page_id: child_page.id)
@@ -159,7 +159,7 @@ RSpec.describe Panda::CMS::Menu, type: :model do
           path: "/test-parent",
           parent: homepage,
           template: template,
-          status: :active
+          status: :published
         )
       end
       let(:alphabetical_menu) do
@@ -173,9 +173,9 @@ RSpec.describe Panda::CMS::Menu, type: :model do
 
       before do
         # Create test pages as children in non-alphabetical order
-        Panda::CMS::Page.create!(title: "Zebra Page", path: "/test-parent/zebra", parent: test_parent, template: template, status: :active)
-        Panda::CMS::Page.create!(title: "Alpha Page", path: "/test-parent/alpha", parent: test_parent, template: template, status: :active)
-        Panda::CMS::Page.create!(title: "Middle Page", path: "/test-parent/middle", parent: test_parent, template: template, status: :active)
+        Panda::CMS::Page.create!(title: "Zebra Page", path: "/test-parent/zebra", parent: test_parent, template: template, status: :published)
+        Panda::CMS::Page.create!(title: "Alpha Page", path: "/test-parent/alpha", parent: test_parent, template: template, status: :published)
+        Panda::CMS::Page.create!(title: "Middle Page", path: "/test-parent/middle", parent: test_parent, template: template, status: :published)
       end
 
       it "orders menu items alphabetically by title" do
@@ -257,13 +257,13 @@ RSpec.describe Panda::CMS::Menu, type: :model do
         path: "/pin-test-parent",
         parent: homepage,
         template: template,
-        status: :active
+        status: :published
       )
     end
 
-    let!(:page_a) { Panda::CMS::Page.create!(title: "Alpha", path: "/pin-test-parent/alpha", parent: test_parent, template: template, status: :active) }
-    let!(:page_b) { Panda::CMS::Page.create!(title: "Beta", path: "/pin-test-parent/beta", parent: test_parent, template: template, status: :active) }
-    let!(:page_c) { Panda::CMS::Page.create!(title: "Gamma", path: "/pin-test-parent/gamma", parent: test_parent, template: template, status: :active) }
+    let!(:page_a) { Panda::CMS::Page.create!(title: "Alpha", path: "/pin-test-parent/alpha", parent: test_parent, template: template, status: :published) }
+    let!(:page_b) { Panda::CMS::Page.create!(title: "Beta", path: "/pin-test-parent/beta", parent: test_parent, template: template, status: :published) }
+    let!(:page_c) { Panda::CMS::Page.create!(title: "Gamma", path: "/pin-test-parent/gamma", parent: test_parent, template: template, status: :published) }
 
     describe "#page_pinned?" do
       it "returns true for a pinned page" do

--- a/spec/models/panda/cms/page_spec.rb
+++ b/spec/models/panda/cms/page_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/", # Root pages are allowed without parent only for path "/"
           panda_cms_template_id: template.id,
           parent: nil,
-          status: "active"
+          status: "published"
         )
         expect(page).to be_valid
       end
@@ -97,7 +97,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/norm-test",
         title: "Normalization Test Root",
         template: test_template,
-        status: "active"
+        status: "published"
       )
       page.save(validate: false)
       page
@@ -109,7 +109,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/norm-test/trailing/",
         parent: test_root,
         panda_cms_template_id: test_template.id,
-        status: "active"
+        status: "published"
       )
 
       page.valid?
@@ -122,7 +122,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/norm-test/multiple///",
         parent: test_root,
         panda_cms_template_id: test_template.id,
-        status: "active"
+        status: "published"
       )
 
       page.valid?
@@ -143,7 +143,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/norm-test/no-trailing",
         parent: test_root,
         panda_cms_template_id: test_template.id,
-        status: "active"
+        status: "published"
       )
 
       page.valid?
@@ -166,7 +166,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/test-root",
         title: "Test Root",
         template: test_template,
-        status: "active"
+        status: "published"
       )
       page.save(validate: false)
       page
@@ -178,7 +178,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         title: "Parent",
         template: test_template,
         parent: root_page,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -188,7 +188,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         title: "Mid Level",
         template: test_template,
         parent: parent_page,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -200,7 +200,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/test-root/parent/nested-page",
           parent: parent_page,
           panda_cms_template_id: test_template.id,
-          status: "active"
+          status: "published"
         )
 
         # Simulate controller logic
@@ -221,7 +221,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/nested-page",
           parent: parent_page,
           panda_cms_template_id: test_template.id,
-          status: "active"
+          status: "published"
         )
 
         # Simulate controller logic
@@ -242,7 +242,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/test-root/parent/mid-level/deep-page",
           parent: mid_level_page,
           panda_cms_template_id: test_template.id,
-          status: "active"
+          status: "published"
         )
 
         # Simulate controller logic
@@ -270,7 +270,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/validation-test",
         title: "Validation Test Root",
         template: test_template,
-        status: "active"
+        status: "published"
       )
       page.save(validate: false)
       page
@@ -282,7 +282,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         title: "Section A",
         template: test_template,
         parent: root_page,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -292,7 +292,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         title: "Section B",
         template: test_template,
         parent: root_page,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -303,7 +303,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         title: "Team A",
         template: test_template,
         parent: section_a,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -314,7 +314,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/validation-test/section-b/team",
         parent: section_b,
         panda_cms_template_id: test_template.id,
-        status: "active"
+        status: "published"
       )
 
       expect(team_under_section_b).to be_valid
@@ -327,7 +327,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/validation-test/section-a/existing",
         parent: section_a,
         panda_cms_template_id: test_template.id,
-        status: "active"
+        status: "published"
       )
 
       duplicate_page = Panda::CMS::Page.new(
@@ -335,7 +335,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/validation-test/section-a/existing",
         parent: section_a,
         panda_cms_template_id: test_template.id,
-        status: "active"
+        status: "published"
       )
 
       expect(duplicate_page).not_to be_valid
@@ -356,7 +356,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/callback-test",
         title: "Callback Test Root",
         template: test_template,
-        status: "active"
+        status: "published"
       )
       page.save(validate: false)
       page
@@ -385,7 +385,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/callback-test/test-page-2",
           parent: test_root,
           template: test_template,
-          status: "active"
+          status: "published"
         )
 
         # Create a mock block
@@ -411,7 +411,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         homepage = Panda::CMS::Page.find_or_create_by!(path: "/") do |p|
           p.title = "Home"
           p.template = test_template
-          p.status = "active"
+          p.status = "published"
         end
         homepage.valid?
         expect(homepage.parent_id).to be_nil
@@ -436,7 +436,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/callback-test/wrong-section",
           parent: test_root,
           template: test_template,
-          status: "active"
+          status: "published"
         )
         page = Panda::CMS::Page.new(
           title: "Misparented Page",
@@ -454,7 +454,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/callback-test/mid",
           parent: test_root,
           template: test_template,
-          status: "active"
+          status: "published"
         )
 
         deep_page = Panda::CMS::Page.new(
@@ -501,7 +501,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/callback-test/old-path",
           parent: test_root,
           template: test_template,
-          status: "active"
+          status: "published"
         )
 
         # Directly test the method by mocking behavior
@@ -525,7 +525,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/callback-test/same-path",
           parent: test_root,
           template: test_template,
-          status: "active"
+          status: "published"
         )
 
         # Directly test the logic - path hasn't changed
@@ -549,7 +549,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/search-test",
         title: "Search Test Root",
         template: test_template,
-        status: "active"
+        status: "published"
       )
       page.save(validate: false)
       page
@@ -561,7 +561,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/search-test/active-page",
         parent: search_root,
         template: test_template,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -571,7 +571,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/search-test/draft-page",
         parent: search_root,
         template: test_template,
-        status: "draft"
+        status: "hidden"
       )
     end
 
@@ -581,7 +581,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/search-test/another-active",
         parent: search_root,
         template: test_template,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -629,7 +629,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         path: "/seo-test",
         title: "SEO Test Root",
         template: test_template,
-        status: "active"
+        status: "published"
       )
       page.save(validate: false)
       page

--- a/spec/models/panda/cms/page_spec.rb
+++ b/spec/models/panda/cms/page_spec.rb
@@ -998,7 +998,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section",
           parent: homepage,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1028,7 +1028,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section/child",
           parent: section_page,
           template: test_template,
-          status: :active
+          status: :published
         )
 
         # Verify the ancestor-based lookup logic that update_auto_menus uses
@@ -1057,7 +1057,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section/mid",
           parent: section_page,
           template: test_template,
-          status: :active
+          status: :published
         )
 
         # Generate the menu - should have section_page + mid_page
@@ -1070,7 +1070,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section/mid/deep",
           parent: mid_page,
           template: test_template,
-          status: :active
+          status: :published
         )
 
         # Verify the ancestor-based lookup logic that update_auto_menus uses
@@ -1100,7 +1100,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section-a",
           parent: homepage,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1110,7 +1110,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section-b",
           parent: homepage,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1136,7 +1136,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section-a/movable",
           parent: section_a,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1188,7 +1188,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section-a/movable/child",
           parent: movable_page,
           template: test_template,
-          status: :active
+          status: :published
         )
 
         # Generate initial menus
@@ -1223,7 +1223,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section",
           parent: homepage,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1241,7 +1241,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section/child",
           parent: section_page,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1259,23 +1259,23 @@ RSpec.describe Panda::CMS::Page, type: :model do
         expect(menu_item.text).to eq("New Title")
       end
 
-      it "regenerates menu when page status changes to draft" do
-        # Change status to draft
-        child_page.update!(status: :draft)
+      it "regenerates menu when page status changes to archived" do
+        # Change status to archived (not servable, removed from menus)
+        child_page.update!(status: :archived)
 
         # Page should be removed from menu
         auto_menu.reload
         expect(auto_menu.menu_items.pluck(:panda_cms_page_id)).not_to include(child_page.id)
       end
 
-      it "regenerates menu when page status changes to active" do
-        # First make it draft
-        child_page.update!(status: :draft)
+      it "regenerates menu when page status changes to published" do
+        # First make it archived
+        child_page.update!(status: :archived)
         auto_menu.reload
         expect(auto_menu.menu_items.pluck(:panda_cms_page_id)).not_to include(child_page.id)
 
-        # Then make it active again
-        child_page.update!(status: :active)
+        # Then make it published again
+        child_page.update!(status: :published)
         auto_menu.reload
         expect(auto_menu.menu_items.pluck(:panda_cms_page_id)).to include(child_page.id)
       end
@@ -1288,7 +1288,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/orphan",
           parent: homepage,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1307,7 +1307,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section",
           parent: homepage,
           template: test_template,
-          status: :active
+          status: :published
         )
       end
 
@@ -1325,7 +1325,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section/child",
           parent: section_page,
           template: test_template,
-          status: :active
+          status: :published
         )
 
         # Spy on the update_auto_menus method
@@ -1344,7 +1344,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
           path: "/section/child",
           parent: section_page,
           template: test_template,
-          status: :active
+          status: :published
         )
 
         # Update title

--- a/spec/models/panda/cms/post_spec.rb
+++ b/spec/models/panda/cms/post_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/test-post",
         user: admin_user,
         author: admin_user,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/active-post",
         user: admin_user,
         author: admin_user,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -57,7 +57,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/draft-post",
         user: admin_user,
         author: admin_user,
-        status: "draft"
+        status: "hidden"
       )
     end
 
@@ -67,7 +67,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/another-active-post",
         user: admin_user,
         author: admin_user,
-        status: "active"
+        status: "published"
       )
     end
 
@@ -112,7 +112,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/test-post",
         user: admin_user,
         author: admin_user,
-        status: "active"
+        status: "published"
       )
     end
 

--- a/spec/requests/panda/cms/sitemaps_spec.rb
+++ b/spec/requests/panda/cms/sitemaps_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Sitemap", type: :request do
         Panda::CMS::Page.create!(
           title: "Draft Page",
           path: "/draft-page",
-          status: :draft,
+          status: :hidden,
           template: panda_cms_templates(:page_template),
           parent: panda_cms_pages(:homepage)
         )
@@ -100,7 +100,7 @@ RSpec.describe "Sitemap", type: :request do
         Panda::CMS::Page.create!(
           title: "Hidden Type Page",
           path: "/hidden-type-page",
-          status: :active,
+          status: :published,
           page_type: :hidden_type,
           template: panda_cms_templates(:page_template),
           parent: panda_cms_pages(:homepage)
@@ -118,7 +118,7 @@ RSpec.describe "Sitemap", type: :request do
         Panda::CMS::Page.create!(
           title: "System Page",
           path: "/system-page",
-          status: :active,
+          status: :published,
           page_type: :system,
           template: panda_cms_templates(:page_template),
           parent: panda_cms_pages(:homepage)
@@ -192,7 +192,7 @@ RSpec.describe "Sitemap", type: :request do
 
     context "with no content" do
       before do
-        Panda::CMS::Page.update_all(status: :draft)
+        Panda::CMS::Page.update_all(status: :hidden)
       end
 
       it "returns a valid empty sitemap" do

--- a/spec/support/shared_contexts/standard_pages.rb
+++ b/spec/support/shared_contexts/standard_pages.rb
@@ -56,7 +56,7 @@ RSpec.shared_context "with standard pages" do
       path: "/",
       title: "Home",
       template: homepage_template,
-      status: "active"
+      status: "published"
     )
   end
 
@@ -66,7 +66,7 @@ RSpec.shared_context "with standard pages" do
       title: "About",
       template: page_template,
       parent: homepage,
-      status: "active"
+      status: "published"
     )
   end
 
@@ -76,7 +76,7 @@ RSpec.shared_context "with standard pages" do
       title: "Services",
       template: page_template,
       parent: homepage,
-      status: "active"
+      status: "published"
     )
   end
 
@@ -86,7 +86,7 @@ RSpec.shared_context "with standard pages" do
       title: "Team",
       template: page_template,
       parent: about_page,
-      status: "active"
+      status: "published"
     )
   end
 
@@ -96,7 +96,7 @@ RSpec.shared_context "with standard pages" do
       title: "Custom Page",
       template: different_page_template,
       parent: homepage,
-      status: "active"
+      status: "published"
     )
   end
 

--- a/spec/system/panda/cms/admin/posts/edit_post_spec.rb
+++ b/spec/system/panda/cms/admin/posts/edit_post_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Editing a post", type: :system do
     @post = Panda::CMS::Post.create!(
       title: "Test Post 1",
       slug: "/#{Time.current.strftime("%Y/%m")}/test-post-1",
-      status: "active",
+      status: "published",
       user: @admin,
       author: @admin,
       published_at: Time.current,


### PR DESCRIPTION
## Summary
- Renames page and post statuses from `active`/`draft`/`hidden`/`archived` to `published`/`unlisted`/`hidden`/`archived`
- Separates page visibility (whether a URL is served) from content workflow (which moves to version-level in panda-cms-pro)
- Adds `.servable` and `.in_sitemap` scopes for cleaner controller queries
- Includes migration with copy-out/drop/recreate pattern for clean PostgreSQL enum swap

## Status Behaviour

| Status | Served? | Auto menus? | Static menus? | Sitemap? |
|---|---|---|---|---|
| `published` | Yes | Yes | Yes | Yes |
| `unlisted` | Yes | No | Yes | Yes |
| `hidden` | Yes | No | No | No |
| `archived` | No | No | No | No |

## Files Changed
- **Models**: Page, Post, Menu — new enum values, new scopes
- **Controllers**: Pages, Posts, Sitemaps — use `.servable` and `.in_sitemap`
- **Views**: Admin page/post edit forms — updated status dropdowns
- **Migration**: PostgreSQL enum swap with data migration
- **Specs**: All fixtures, shared contexts, and test files updated
- **Schema**: Enum types and column defaults updated

## Test plan
- [ ] `bundle exec rspec` passes in panda-cms
- [ ] Migration runs cleanly on PostgreSQL
- [ ] Auto menus only include `published` pages
- [ ] Sitemap includes `published` and `unlisted`, excludes `hidden` and `archived`
- [ ] Archived pages return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)