### PR TITLE
Fix EditorJS classList error on form submission

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: e5572a4deeee4902439b90f0c56d4e61852d3123
+  revision: 0199ee0a53172deb8a4b6a61478a3077e14187f9
   branch: main
   specs:
     panda-editor (0.8.3)
@@ -538,7 +538,7 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     version_gem (1.1.9)
-    view_component (4.2.0)
+    view_component (4.3.0)
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)
       concurrent-ruby (~> 1)

--- a/app/javascript/panda/cms/controllers/editor_form_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_form_controller.js
@@ -260,13 +260,13 @@ export default class extends Controller {
   async submit(event) {
     // Prevent the default button click behavior temporarily
     event.preventDefault();
-    
+
     const submitButton = event.target;
     const form = submitButton.closest('form');
-    
+
     // Re-enable the button that was disabled by data-disable-with
     submitButton.disabled = false;
-    
+
     // Ensure editor content is saved before form submission
     if (this.editor) {
       try {
@@ -278,20 +278,32 @@ export default class extends Controller {
       } catch (error) {
         console.error("[Panda CMS] Failed to save editor content:", error);
       }
+
+      // Destroy the editor before form submission so its document-level
+      // click handler is removed. Without this, the synthetic click below
+      // bubbles to `document`, EditorJS's `documentClicked` fires, and it
+      // tries to access toolbar DOM elements that Turbo has already removed
+      // — causing "Cannot read properties of undefined (reading 'classList')".
+      try {
+        this.editor.destroy();
+      } catch (e) {
+        console.debug("[Panda CMS] Editor cleanup before submit (safe to ignore):", e.message);
+      }
+      this.editor = null;
     }
-    
+
     // Now trigger the normal form submission (this will let Rails/Turbo handle it properly)
     if (form) {
       // Remove our custom action to prevent infinite loop
       submitButton.removeAttribute('data-action');
-      
+
       // Create a new click event that will trigger the normal form submission
       const clickEvent = new MouseEvent('click', {
         bubbles: true,
         cancelable: true,
         view: window
       });
-      
+
       // Dispatch the click event, which will trigger normal Rails form submission
       submitButton.dispatchEvent(clickEvent);
     }

--- a/app/javascript/panda/cms/controllers/editor_form_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_form_controller.js
@@ -280,10 +280,13 @@ export default class extends Controller {
       }
 
       // Destroy the editor before form submission so its document-level
-      // click handler is removed. Without this, the synthetic click below
-      // bubbles to `document`, EditorJS's `documentClicked` fires, and it
-      // tries to access toolbar DOM elements that Turbo has already removed
-      // — causing "Cannot read properties of undefined (reading 'classList')".
+      // click handler is removed. Without this, the *original* trusted click
+      // can keep bubbling after `submit()` returns, reach `document`, and
+      // trigger EditorJS's `documentClicked`, which then tries to access
+      // toolbar DOM elements that Turbo has already removed — causing
+      // "Cannot read properties of undefined (reading 'classList')". The
+      // synthetic click we dispatch below is non-trusted and ignored by
+      // `documentClicked` in the vendored EditorJS build.
       try {
         this.editor.destroy();
       } catch (e) {

--- a/app/javascript/panda/cms/controllers/editor_form_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_form_controller.js
@@ -261,7 +261,7 @@ export default class extends Controller {
     // Prevent the default button click behavior temporarily
     event.preventDefault();
 
-    const submitButton = event.target;
+    const submitButton = event.currentTarget;
     const form = submitButton.closest('form');
 
     // Re-enable the button that was disabled by data-disable-with

--- a/spec/models/panda/cms/page_spec.rb
+++ b/spec/models/panda/cms/page_spec.rb
@@ -1016,7 +1016,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         section_page.reload
         auto_menu.reload
         auto_menu.generate_auto_menu_items
-        
+
         initial_count = auto_menu.menu_items.count
         expect(initial_count).to eq(1)
 
@@ -1034,7 +1034,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         # Verify the ancestor-based lookup logic that update_auto_menus uses
         ancestor_ids = child_page.self_and_ancestors.pluck(:id)
         expect(ancestor_ids).to include(section_page.id)
-        
+
         # Verify that the menu would be found by the update_auto_menus query
         menus = Panda::CMS::Menu.where(kind: "auto", start_page_id: ancestor_ids)
         expect(menus).to include(auto_menu)
@@ -1077,7 +1077,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         # Deep page should have ancestors: [homepage, section_page, mid_page]
         ancestor_ids = deep_page.self_and_ancestors.pluck(:id)
         expect(ancestor_ids).to include(section_page.id, mid_page.id)
-        
+
         # Verify that the menu would be found (start_page is in ancestors)
         menus = Panda::CMS::Menu.where(kind: "auto", start_page_id: ancestor_ids)
         expect(menus).to include(auto_menu)
@@ -1143,7 +1143,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
       it "adds page to new menu when moved to different section" do
         # Ensure the movable page exists before generating menus
         movable_page.reload
-        
+
         # Generate initial menus - this should include movable_page in menu_a
         menu_a.generate_auto_menu_items
         menu_b.generate_auto_menu_items
@@ -1176,7 +1176,7 @@ RSpec.describe Panda::CMS::Page, type: :model do
         # Verify page is now in menu B
         menu_b.reload
         expect(menu_b.menu_items.pluck(:panda_cms_page_id)).to include(movable_page.id)
-        
+
         # Note: menu_a is not automatically cleaned up because update_auto_menus
         # only looks at NEW ancestors after the move, not old ancestors
       end

--- a/spec/system/panda/cms/admin/posts/post_form_seo_spec.rb
+++ b/spec/system/panda/cms/admin/posts/post_form_seo_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe "Post form SEO functionality", type: :system do
   end
 
   describe "validation errors" do
-    it "shows validation errors when SEO title is too long", skip: "EditorJS classList error on click_button in CI" do
+    it "shows validation errors when SEO title is too long" do
       visit "/admin/cms/posts/#{post.id}/edit"
       expect(page).to have_content(post.title, wait: 10)
 
@@ -197,7 +197,7 @@ RSpec.describe "Post form SEO functionality", type: :system do
       expect(page).to have_content(/too long/i, wait: 5)
     end
 
-    it "shows validation errors when SEO description is too long", skip: "EditorJS classList error on click_button in CI" do
+    it "shows validation errors when SEO description is too long" do
       visit "/admin/cms/posts/#{post.id}/edit"
       expect(page).to have_content(post.title, wait: 10)
 


### PR DESCRIPTION
## Summary
- Destroys the EditorJS instance after saving content but before dispatching the synthetic click event in `editor_form_controller.js`'s `submit()` method
- This removes EditorJS's document-level `documentClicked` handler so it doesn't fire on stale DOM references during Turbo navigation, which was causing `TypeError: Cannot read properties of undefined (reading 'classList')`
- Re-enables two SEO validation tests that were skipped for this issue
- Fixes trailing whitespace in `page_spec.rb` and updates `view_component`

## Root cause
The submit button has `data-action="click->editor-form#submit"`. Our `submit()` method:
1. Prevents default
2. Saves editor content to hidden field
3. Dispatches a **new synthetic click** on the button

That synthetic click bubbles to `document`, where EditorJS's internal `documentClicked` handler catches it and tries to close the inline toolbar. But Turbo has started navigation by this point, so the toolbar DOM elements are already destroyed — causing the classList error.

The fix adds `this.editor.destroy()` between steps 2 and 3, which removes EditorJS's event listeners before the synthetic click fires.

## Test plan
- [ ] CI passes (especially `post_form_seo_spec.rb` tests that were previously failing/skipped)
- [ ] Post creation and editing still works in admin UI
- [ ] EditorJS content is properly saved on form submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)