### PR TITLE
Handle Hash input in render_content_for_display

### DIFF
--- a/app/components/panda/cms/rich_text_component.rb
+++ b/app/components/panda/cms/rich_text_component.rb
@@ -221,8 +221,14 @@ module Panda
       end
 
       def render_content_for_display(content)
-        # Try to parse as JSON if it looks like EditorJS format
-        if content.is_a?(String) && content.strip.match?(/^\{.*"blocks":\s*\[.*\].*\}$/m)
+        # Handle Hash input (from content accessor which auto-parses JSON)
+        if content.is_a?(Hash)
+          if valid_editor_js_content?(content)
+            render_editor_js_content(content)
+          else
+            process_html_content(content.to_s)
+          end
+        elsif content.is_a?(String) && content.strip.match?(/^\{.*"blocks":\s*\[.*\].*\}$/m)
           parsed_content = JSON.parse(content)
           if valid_editor_js_content?(parsed_content)
             render_editor_js_content(parsed_content)
@@ -230,10 +236,10 @@ module Panda
             process_html_content(content)
           end
         else
-          process_html_content(content)
+          process_html_content(content.to_s)
         end
       rescue JSON::ParserError
-        process_html_content(content)
+        process_html_content(content.to_s)
       end
 
       def render_editor_js_content(parsed_content)

--- a/app/components/panda/cms/rich_text_component.rb
+++ b/app/components/panda/cms/rich_text_component.rb
@@ -222,9 +222,11 @@ module Panda
 
       def render_content_for_display(content)
         # Handle Hash input (from content accessor which auto-parses JSON)
+        # Normalize keys to strings since empty_editor_js_content uses symbols
         if content.is_a?(Hash)
-          if valid_editor_js_content?(content)
-            render_editor_js_content(content)
+          stringified = content.deep_stringify_keys
+          if valid_editor_js_content?(stringified)
+            render_editor_js_content(stringified)
           else
             process_html_content(content.to_s)
           end


### PR DESCRIPTION
## Summary
- The `Panda::Editor::Content` module's `content` accessor auto-parses JSON returning a Hash
- When `cached_content` is nil, the fallback to raw content passes a Hash to `render_content_for_display` which only handled String input
- This caused `NoMethodError` on `Hash#match?`, silently rendering blank content via the error handler
- Fix: handle Hash input directly by routing to `render_editor_js_content` when valid EditorJS

## Test plan
- [x] All RichTextComponent specs pass
- [ ] Verify on staging that pages render correctly when cached_content is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)