### PR TITLE
Install panda-core migration for ActiveStorage record_id fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 0dcce68780e5bf713387c73de5e8224b1dfba623
+  revision: 0b8c22f3478791ecca811993b4ec84105ff5ffbd
   branch: main
   specs:
     panda-core (0.14.4)
@@ -130,7 +130,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
-    annotaterb (4.21.0)
+    annotaterb (4.22.0)
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     ast (2.4.3)

--- a/spec/dummy/db/migrate/20260212092127_fix_active_storage_attachments_record_id_type.panda_core.rb
+++ b/spec/dummy/db/migrate/20260212092127_fix_active_storage_attachments_record_id_type.panda_core.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This migration comes from panda_core (originally 20260213000001)
+class FixActiveStorageAttachmentsRecordIdType < ActiveRecord::Migration[8.1]
+  def up
+    return unless table_exists?(:active_storage_attachments)
+
+    column = columns(:active_storage_attachments).find { |c| c.name == "record_id" }
+    return if column.nil? || column.sql_type == "character varying"
+
+    # Remove orphaned attachments where UUID was silently cast to 0
+    execute <<~SQL
+      DELETE FROM active_storage_attachments WHERE record_id = 0
+    SQL
+
+    # Drop the unique index before changing the column type
+    remove_index :active_storage_attachments,
+      name: "index_active_storage_attachments_uniqueness",
+      if_exists: true
+
+    change_column :active_storage_attachments, :record_id, :string, null: false
+
+    add_index :active_storage_attachments,
+      [:record_type, :record_id, :name, :blob_id],
+      unique: true,
+      name: "index_active_storage_attachments_uniqueness"
+  end
+
+  def down
+    return unless table_exists?(:active_storage_attachments)
+
+    remove_index :active_storage_attachments,
+      name: "index_active_storage_attachments_uniqueness",
+      if_exists: true
+
+    change_column :active_storage_attachments, :record_id, :bigint,
+      null: false,
+      using: "record_id::bigint"
+
+    add_index :active_storage_attachments,
+      [:record_type, :record_id, :name, :blob_id],
+      unique: true,
+      name: "index_active_storage_attachments_uniqueness"
+  end
+end

--- a/spec/dummy/db/migrate/20260212092127_fix_active_storage_attachments_record_id_type.panda_core.rb
+++ b/spec/dummy/db/migrate/20260212092127_fix_active_storage_attachments_record_id_type.panda_core.rb
@@ -9,9 +9,12 @@ class FixActiveStorageAttachmentsRecordIdType < ActiveRecord::Migration[8.1]
     return if column.nil? || column.sql_type == "character varying"
 
     # Remove orphaned attachments where UUID was silently cast to 0
-    execute <<~SQL
-      DELETE FROM active_storage_attachments WHERE record_id = 0
-    SQL
+    # Only run when column is numeric (bigint/integer) to avoid type mismatch errors
+    if %w[bigint integer].include?(column.sql_type)
+      execute <<~SQL
+        DELETE FROM active_storage_attachments WHERE record_id = 0
+      SQL
+    end
 
     # Drop the unique index before changing the column type
     remove_index :active_storage_attachments,
@@ -27,19 +30,7 @@ class FixActiveStorageAttachmentsRecordIdType < ActiveRecord::Migration[8.1]
   end
 
   def down
-    return unless table_exists?(:active_storage_attachments)
-
-    remove_index :active_storage_attachments,
-      name: "index_active_storage_attachments_uniqueness",
-      if_exists: true
-
-    change_column :active_storage_attachments, :record_id, :bigint,
-      null: false,
-      using: "record_id::bigint"
-
-    add_index :active_storage_attachments,
-      [:record_type, :record_id, :name, :blob_id],
-      unique: true,
-      name: "index_active_storage_attachments_uniqueness"
+    raise ActiveRecord::IrreversibleMigration,
+      "Cannot safely convert record_id back to bigint after UUID values have been stored"
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_11_175501) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_092127) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,7 +47,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_175501) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.bigint "record_id", null: false
+    t.string "record_id", null: false
     t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true


### PR DESCRIPTION
## Summary

- Installs the panda-core engine migration that fixes `active_storage_attachments.record_id` type
- Updates dummy app schema to reflect `string` type for `record_id`

## Context

Depends on tastybamboo/panda-core#109. The panda-core migration changes `record_id` from `bigint` to `string` to support UUID primary keys introduced by panda-core's `GeneratorConfig`.

## Test plan

- [x] panda-cms specs pass
- [x] Schema shows `t.string "record_id"` after migration
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)