### PR TITLE
Call patchLinkAutocomplete in editor form controller

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 0b8c22f3478791ecca811993b4ec84105ff5ffbd
+  revision: d7913f7bcb3a83179f670b5e6c64e09eb61a5da2
   branch: main
   specs:
     panda-core (0.14.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: 0199ee0a53172deb8a4b6a61478a3077e14187f9
+  revision: 0cefc492c928e4d7ac42c0d8880a420dfdd1fe65
   branch: main
   specs:
     panda-editor (0.8.3)
@@ -433,7 +433,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.7)
-    rubocop (1.82.1)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -441,7 +441,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.49.0)
@@ -495,10 +495,10 @@ GEM
       version_gem (>= 1.1.8, < 3)
     sqlite3 (2.9.0-arm64-darwin)
     sqlite3 (2.9.0-x86_64-linux-gnu)
-    standard (1.53.0)
+    standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.82.0)
+      rubocop (~> 1.84.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)

--- a/app/javascript/panda/cms/controllers/editor_form_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_form_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
-import { EDITOR_JS_RESOURCES, EDITOR_JS_CSS, initializeEditorUndo } from "panda/editor/editor_js_config";
+import { EDITOR_JS_RESOURCES, EDITOR_JS_CSS, initializeEditorUndo, patchLinkAutocomplete } from "panda/editor/editor_js_config";
 import { ResourceLoader } from "panda/editor/resource_loader";
 
 // UTF-8 safe Base64 helpers — atob/btoa only handle Latin-1, corrupting multi-byte characters
@@ -45,6 +45,8 @@ export default class extends Controller {
       for (const resource of EDITOR_JS_RESOURCES.slice(1)) {
         await ResourceLoader.loadScript(document, document.head, resource);
       }
+
+      patchLinkAutocomplete(window);
 
       await this.initializeEditor();
     } catch (error) {

--- a/app/models/panda/cms/menu.rb
+++ b/app/models/panda/cms/menu.rb
@@ -32,7 +32,7 @@ module Panda
         # NB: Transactions are not distributed across database connections
         transaction do
           menu_items.destroy_all
-          menu_item_root = menu_items.create(text: start_page.title, panda_cms_page_id: start_page.id)
+          menu_item_root = menu_items.create!(text: start_page.title, panda_cms_page_id: start_page.id)
           generate_menu_items(parent_menu_item: menu_item_root, parent_page: start_page)
         end
 
@@ -63,7 +63,7 @@ module Panda
         children = order_pages(children)
 
         children.each do |page|
-          menu_item = menu_items.create(text: page.title, panda_cms_page_id: page.id, parent: parent_menu_item)
+          menu_item = menu_items.create!(text: page.title, panda_cms_page_id: page.id, parent: parent_menu_item)
           generate_menu_items(parent_menu_item: menu_item, parent_page: page) if page.children
         end
       end

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -103,10 +103,22 @@ module Panda
       # @visibility public
       #
       def update_auto_menus
-        return unless should_update_auto_menus?
+        unless should_update_auto_menus?
+          Rails.logger.debug { "[Panda CMS] Skipping auto menu update for page #{id} (#{path}) — no relevant changes" }
+          return
+        end
+
+        reason = auto_menu_update_reason
+        Rails.logger.info { "[Panda CMS] Updating auto menus for page #{id} (#{path}): #{reason}" }
 
         ancestor_ids = self_and_ancestors.pluck(:id)
-        Panda::CMS::Menu.where(kind: "auto", start_page_id: ancestor_ids).find_each(&:generate_auto_menu_items)
+        menus = Panda::CMS::Menu.where(kind: "auto", start_page_id: ancestor_ids)
+        Rails.logger.debug { "[Panda CMS] Found #{menus.count} auto menu(s) to regenerate" }
+
+        menus.find_each do |menu|
+          Rails.logger.info { "[Panda CMS] Regenerating auto menu '#{menu.name}' (id=#{menu.id})" }
+          menu.generate_auto_menu_items
+        end
       end
 
       #
@@ -146,7 +158,7 @@ module Panda
         return title unless inherit_seo
 
         # Traverse up tree to find inherited value
-        self_and_ancestors.to_a.reverse.find { |p| p.seo_title.present? }&.seo_title || title
+        self_and_ancestors.to_a.rfind { |p| p.seo_title.present? }&.seo_title || title
       end
 
       #
@@ -160,7 +172,7 @@ module Panda
         return seo_description if seo_description.present?
         return nil unless inherit_seo
 
-        self_and_ancestors.to_a.reverse.find { |p| p.seo_description.present? }&.seo_description
+        self_and_ancestors.to_a.rfind { |p| p.seo_description.present? }&.seo_description
       end
 
       #
@@ -332,6 +344,15 @@ module Panda
 
       def should_update_auto_menus?
         previously_new_record? || saved_change_to_title? || saved_change_to_status? || saved_change_to_path?
+      end
+
+      def auto_menu_update_reason
+        reasons = []
+        reasons << "new page" if previously_new_record?
+        reasons << "title changed" if saved_change_to_title?
+        reasons << "status changed to #{status}" if saved_change_to_status?
+        reasons << "path changed" if saved_change_to_path?
+        reasons.join(", ")
       end
 
       def cache_ancestor_ids_for_menu_update

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -146,7 +146,7 @@ module Panda
         return title unless inherit_seo
 
         # Traverse up tree to find inherited value
-        self_and_ancestors.reverse.find { |p| p.seo_title.present? }&.seo_title || title
+        self_and_ancestors.to_a.reverse.find { |p| p.seo_title.present? }&.seo_title || title
       end
 
       #
@@ -160,7 +160,7 @@ module Panda
         return seo_description if seo_description.present?
         return nil unless inherit_seo
 
-        self_and_ancestors.reverse.find { |p| p.seo_description.present? }&.seo_description
+        self_and_ancestors.to_a.reverse.find { |p| p.seo_description.present? }&.seo_description
       end
 
       #

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -107,7 +107,8 @@ Rails.application.configure do
   config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  config.action_view.annotate_rendered_view_with_filenames = true
+  # Disabled: incompatible with ViewComponent template compilation on Ruby 4.0+
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true

--- a/spec/system/panda/cms/admin/posts/post_form_seo_spec.rb
+++ b/spec/system/panda/cms/admin/posts/post_form_seo_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-RSpec.describe "Post form SEO functionality", type: :system do
+RSpec.describe "Post form SEO functionality", type: :system, editorjs: true do
   fixtures :all
 
   let(:admin) { create_admin_user }


### PR DESCRIPTION
## Summary

- Import and call `patchLinkAutocomplete(window)` in `editor_form_controller.js` after loading editor scripts, so the post form editor also accepts relative URLs (`/path`) and anchor links (`#section`)

This is the panda-cms counterpart to tastybamboo/panda-editor#14 — the patch function is defined in panda-editor and called here for the direct (non-iframe) editor context.

## Test plan

- [ ] Open a post form editor, select text, click the link icon
- [ ] Type `/get-help-now` and press Enter — should accept it
- [ ] Type `#my-section` and press Enter — should accept it
- [ ] Type `https://example.com` — should still work
- [ ] Search for a page name — autocomplete dropdown should appear and selection should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)