### PR TITLE
Add helpdesk_form block type for CMS pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: d7913f7bcb3a83179f670b5e6c64e09eb61a5da2
+  revision: 4fd60799f4fa4536f82e3fb6645785b40c346d3d
   branch: main
   specs:
     panda-core (0.14.4)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
-  revision: 0cefc492c928e4d7ac42c0d8880a420dfdd1fe65
+  revision: 8be395dcea54e68aabb743ac70efbd16822c9aea
   branch: main
   specs:
     panda-editor (0.8.3)
@@ -27,7 +27,7 @@ GIT
       panda-core
       rails (>= 7.1)
       redcarpet (~> 3.6)
-      sanitize (~> 6.0)
+      sanitize (>= 6.0)
 
 PATH
   remote: .

--- a/app/components/panda/cms/helpdesk_form_component.html.erb
+++ b/app/components/panda/cms/helpdesk_form_component.html.erb
@@ -1,0 +1,48 @@
+<% if @editable_state && helpdesk_available? %>
+  <div data-controller="inline-form-selector"
+       data-inline-form-selector-page-id-value="<%= Panda::CMS::Current.page.id %>"
+       data-inline-form-selector-block-content-id-value="<%= @block_content_id %>"
+       class="panda-cms-form-selector border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+    <div class="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-2 flex items-center justify-between">
+      <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Helpdesk Form Block</span>
+      <div class="flex items-center gap-2">
+        <select data-inline-form-selector-target="formSelect"
+                data-action="change->inline-form-selector#previewForm"
+                class="text-sm border-gray-300 rounded-md shadow-sm focus:border-primary focus:ring-primary dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
+          <option value="">-- No department selected --</option>
+          <% @available_departments&.each do |dept| %>
+            <option value="<%= dept.id %>" <%= "selected" if @department_id == dept.id.to_s %>>
+              <%= dept.name %>
+            </option>
+          <% end %>
+        </select>
+        <button type="button"
+                data-action="click->inline-form-selector#saveSelection"
+                class="px-3 py-1 text-sm font-medium text-white bg-primary hover:bg-primary-dark rounded-md">
+          Save
+        </button>
+      </div>
+      <div data-inline-form-selector-target="saveMessage" class="hidden"></div>
+    </div>
+    <div data-inline-form-selector-target="previewArea" class="p-4">
+      <% if @department %>
+        <div class="text-center py-4 text-gray-500">
+          <p class="text-sm font-medium">Department: <%= @department.name %></p>
+          <p class="text-xs mt-1">The helpdesk form will be shown here to logged-in visitors.</p>
+        </div>
+      <% else %>
+        <div class="text-center py-8 text-gray-400">
+          <p class="text-sm">No department selected. Choose a department from the dropdown above.</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% elsif @editable_state && !helpdesk_available? %>
+  <div class="border border-amber-200 bg-amber-50 rounded-lg p-4">
+    <p class="text-sm text-amber-800">
+      Helpdesk form: The panda-helpdesk gem is not installed. Add it to your Gemfile to enable helpdesk forms.
+    </p>
+  </div>
+<% elsif helpdesk_available? && @department %>
+  <%= render Panda::Helpdesk::EmbeddedFormComponent.new(department: @department, current_user: @current_user) %>
+<% end %>

--- a/app/components/panda/cms/helpdesk_form_component.rb
+++ b/app/components/panda/cms/helpdesk_form_component.rb
@@ -93,7 +93,8 @@ module Panda
       def resolve_current_user
         return nil unless helpdesk_available?
         Panda::Helpdesk.config.current_user_resolver.call(view_context.session, view_context.request)
-      rescue
+      rescue StandardError => e
+        Rails.logger.error("[HelpdeskFormComponent] Failed to resolve current user: #{e.class}: #{e.message}") if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
         nil
       end
     end

--- a/app/components/panda/cms/helpdesk_form_component.rb
+++ b/app/components/panda/cms/helpdesk_form_component.rb
@@ -35,10 +35,7 @@ module Panda
       def prepare_content
         @editable_state = component_is_editable?
 
-        unless helpdesk_available?
-          @editable_state = false if @editable_state
-          return
-        end
+        return unless helpdesk_available?
 
         block = find_block
         if block.nil?
@@ -93,8 +90,8 @@ module Panda
       def resolve_current_user
         return nil unless helpdesk_available?
         Panda::Helpdesk.config.current_user_resolver.call(view_context.session, view_context.request)
-      rescue StandardError => e
-        Rails.logger.error("[HelpdeskFormComponent] Failed to resolve current user: #{e.class}: #{e.message}") if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+      rescue => e
+        Rails.logger.error("[HelpdeskFormComponent] Failed to resolve current user: #{e.class}: #{e.message}")
         nil
       end
     end

--- a/app/components/panda/cms/helpdesk_form_component.rb
+++ b/app/components/panda/cms/helpdesk_form_component.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    # Helpdesk form component for embedding helpdesk ticket forms into CMS page templates.
+    # Admins select which helpdesk department to display via a dropdown in the page editor.
+    # Requires panda-helpdesk gem to be installed; degrades gracefully if not present.
+    # @param key [Symbol] The key to use for the helpdesk form component
+    # @param editable [Boolean] If the component is editable or not (defaults to true)
+    class HelpdeskFormComponent < Panda::Core::Base
+      KIND = "helpdesk_form"
+
+      attr_reader :key, :editable
+
+      def initialize(key:, editable: true, **attrs)
+        @key = key
+        @editable = editable
+        super(**attrs)
+      end
+
+      def before_render
+        prepare_content
+      end
+
+      # Depends on auth state, so must not be cached
+      def should_cache?
+        false
+      end
+
+      private
+
+      attr_accessor :block_content_obj, :department_id, :department, :available_departments,
+        :block_content_id, :editable_state, :current_user
+
+      def prepare_content
+        @editable_state = component_is_editable?
+
+        unless helpdesk_available?
+          @editable_state = false if @editable_state
+          return
+        end
+
+        block = find_block
+        if block.nil?
+          @editable_state = false
+          return
+        end
+
+        @block_content_obj = find_block_content(block)
+        @department_id = @block_content_obj&.content.to_s.presence
+        @block_content_id = @block_content_obj&.id
+        @department = Panda::Helpdesk::Department.find_by(id: @department_id) if @department_id
+        @available_departments = Panda::Helpdesk::Department.active.order(:name) if @editable_state
+        @current_user = resolve_current_user unless @editable_state
+      end
+
+      def find_block
+        Panda::CMS::Block.find_by(
+          kind: KIND,
+          key: @key,
+          panda_cms_template_id: Current.page.panda_cms_template_id
+        )
+      end
+
+      def find_block_content(block)
+        block.block_contents.find_by(panda_cms_page_id: Current.page.id)
+      end
+
+      def component_is_editable?
+        @editable && is_embedded?
+      end
+
+      def is_embedded?
+        page_id = Current.page&.id.to_s
+
+        editing_page_id = view_context.session[:panda_cms_editing_page_id]
+        editing_expires_at = view_context.session[:panda_cms_editing_expires_at]
+
+        session_valid = editing_page_id == page_id &&
+          editing_expires_at.present? &&
+          Time.parse(editing_expires_at) > Time.current
+
+        embed_id = view_context.params[:embed_id].to_s
+        url_param_valid = embed_id.present? && embed_id == page_id
+
+        session_valid || url_param_valid
+      end
+
+      def helpdesk_available?
+        defined?(Panda::Helpdesk)
+      end
+
+      def resolve_current_user
+        return nil unless helpdesk_available?
+        Panda::Helpdesk.config.current_user_resolver.call(view_context.session, view_context.request)
+      rescue
+        nil
+      end
+    end
+  end
+end

--- a/app/javascript/panda/cms/controllers/inline_form_selector_controller.js
+++ b/app/javascript/panda/cms/controllers/inline_form_selector_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
       wrapper.className = 'text-center py-8 text-gray-400'
       const msg = document.createElement('p')
       msg.className = 'text-sm'
-      msg.textContent = 'No form selected. Choose a form from the dropdown above.'
+      msg.textContent = 'No selection made. Choose an option from the dropdown above.'
       wrapper.appendChild(msg)
       this.previewAreaTarget.appendChild(wrapper)
       return
@@ -33,7 +33,7 @@ export default class extends Controller {
     nameEl.textContent = selectedOption.text.trim()
     const hintEl = document.createElement('p')
     hintEl.className = 'text-xs mt-1'
-    hintEl.textContent = 'Save and reload to see the full form preview.'
+    hintEl.textContent = 'Save and reload to see the full preview.'
     wrapper.appendChild(nameEl)
     wrapper.appendChild(hintEl)
     this.previewAreaTarget.appendChild(wrapper)
@@ -57,17 +57,17 @@ export default class extends Controller {
       })
 
       if (response.ok) {
-        this.showSaveMessage('Form selection saved!', 'success')
+        this.showSaveMessage('Selection saved!', 'success')
 
         setTimeout(() => {
           window.location.reload()
         }, 1000)
       } else {
-        this.showSaveMessage('Error saving form selection', 'error')
+        this.showSaveMessage('Error saving selection', 'error')
       }
     } catch (error) {
-      console.error('Error saving form selection:', error)
-      this.showSaveMessage('Error saving form selection', 'error')
+      console.error('Error saving selection:', error)
+      this.showSaveMessage('Error saving selection', 'error')
     }
   }
 

--- a/app/models/panda/cms/block.rb
+++ b/app/models/panda/cms/block.rb
@@ -23,7 +23,8 @@ module Panda
         code: "code",
         iframe: "iframe",
         quote: "quote",
-        form: "form"
+        form: "form",
+        helpdesk_form: "helpdesk_form"
       }
     end
   end

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -146,7 +146,7 @@ module Panda
         return title unless inherit_seo
 
         # Traverse up tree to find inherited value
-        self_and_ancestors.reverse.find { |p| p.seo_title.present? }&.seo_title || title
+        self_and_ancestors.to_a.rfind { |p| p.seo_title.present? }&.seo_title || title
       end
 
       #
@@ -160,7 +160,7 @@ module Panda
         return seo_description if seo_description.present?
         return nil unless inherit_seo
 
-        self_and_ancestors.reverse.find { |p| p.seo_description.present? }&.seo_description
+        self_and_ancestors.to_a.rfind { |p| p.seo_description.present? }&.seo_description
       end
 
       #

--- a/db/migrate/20260213000001_add_helpdesk_form_to_block_kind.rb
+++ b/db/migrate/20260213000001_add_helpdesk_form_to_block_kind.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddHelpdeskFormToBlockKind < ActiveRecord::Migration[8.1]
+  def up
+    execute "ALTER TYPE panda_cms_block_kind ADD VALUE IF NOT EXISTS 'helpdesk_form'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/components/panda/cms/helpdesk_form_component_spec.rb
+++ b/spec/components/panda/cms/helpdesk_form_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::HelpdeskFormComponent, type: :component do
+  describe "constants" do
+    it "has KIND set to 'helpdesk_form'" do
+      expect(described_class::KIND).to eq("helpdesk_form")
+    end
+  end
+
+  describe "initialization" do
+    it "accepts key property" do
+      component = described_class.new(key: :helpdesk_form, editable: false)
+      expect(component).to be_a(described_class)
+    end
+
+    it "defaults editable to true" do
+      component = described_class.new(key: :helpdesk_form)
+      expect(component.editable).to be true
+    end
+  end
+
+  describe "#should_cache?" do
+    it "returns false because form depends on auth state" do
+      component = described_class.new(key: :helpdesk_form)
+      expect(component.should_cache?).to be false
+    end
+  end
+
+  describe "#helpdesk_available?" do
+    it "checks if Panda::Helpdesk is defined" do
+      component = described_class.new(key: :helpdesk_form)
+      # In the CMS test environment, helpdesk is not loaded
+      result = component.send(:helpdesk_available?)
+      if defined?(Panda::Helpdesk)
+        expect(result).to be_truthy
+      else
+        expect(result).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `helpdesk_form` to the Block kind enum with a PostgreSQL migration (`ADD VALUE IF NOT EXISTS`)
- Adds `HelpdeskFormComponent` that wraps `Panda::Helpdesk::EmbeddedFormComponent` for CMS page templates
- Edit mode: department selector dropdown using existing `inline-form-selector` Stimulus controller
- View mode: delegates to panda-helpdesk's `EmbeddedFormComponent` with resolved current user
- Graceful degradation: checks `defined?(Panda::Helpdesk)` — shows warning in edit mode, renders nothing in view mode if gem not installed
- `should_cache?` returns false since rendered content depends on authentication state

## Dependencies
- Requires [tastybamboo/panda-helpdesk#15](https://github.com/tastybamboo/panda-helpdesk/pull/15) for `EmbeddedFormComponent`

## Test plan
- [x] Component spec: KIND constant, initialization, should_cache?, helpdesk_available?
- [x] 5/5 passing

> **Note:** `render_inline` tests are skipped due to a pre-existing ViewComponent + Ruby 4.0 Prism parser incompatibility affecting all ViewComponent render tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)