### PR TITLE
Add archive-aware page filtering and admin UI toggle

### DIFF
--- a/app/controllers/panda/cms/admin/pages_controller.rb
+++ b/app/controllers/panda/cms/admin/pages_controller.rb
@@ -12,7 +12,9 @@ module Panda
         # @return ActiveRecord::Collection A list of all pages
         def index
           homepage = Panda::CMS::Page.find_by(path: "/")
-          render :index, locals: {root_page: homepage}
+          archived_count = Panda::CMS::Page.archived.count
+          show_archived = params[:show_archived] == "true"
+          render :index, locals: {root_page: homepage, archived_count: archived_count, show_archived: show_archived}
         end
 
         # Loads the add page form

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -50,6 +50,7 @@ module Panda
       }
 
       scope :servable, -> { where(status: [:published, :unlisted, :hidden]) }
+      scope :not_archived, -> { where.not(status: :archived) }
       scope :in_sitemap, -> { where(status: [:published, :unlisted]) }
 
       enum :page_type, {
@@ -268,8 +269,8 @@ module Panda
         # Skip validation if path is not present (other validations will catch this)
         return if path.blank?
 
-        # Find any other pages with the same path
-        other_page = self.class.where(path: path).where.not(id: id).first
+        # Find any other non-archived pages with the same path
+        other_page = self.class.where(path: path).where.not(id: id).not_archived.first
 
         return unless other_page
         # If there's another page with the same path, check if it has a different parent

--- a/app/views/panda/cms/admin/pages/index.html.erb
+++ b/app/views/panda/cms/admin/pages/index.html.erb
@@ -4,10 +4,11 @@
   <% end %>
 
   <% if root_page %>
+    <% page_rows = show_archived ? root_page.self_and_descendants : root_page.self_and_descendants.not_archived %>
     <div data-controller="tree" data-tree-target="container" style="opacity: 0; transition: opacity 0.2s;">
-      <%= render Panda::Core::Admin::TableComponent.new(term: "page", rows: root_page.self_and_descendants) do |table| %>
+      <%= render Panda::Core::Admin::TableComponent.new(term: "page", rows: page_rows) do |table| %>
         <% table.column("Name") do |page| %>
-          <div class="flex flex-col" data-tree-target="row" data-page-id="<%= page.id %>" data-level="<%= page.level %>" data-parent-id="<%= page.parent_id %>">
+          <div class="flex flex-col <%= "opacity-50" if page.archived? %>" data-tree-target="row" data-page-id="<%= page.id %>" data-level="<%= page.level %>" data-parent-id="<%= page.parent_id %>">
             <%# Add indentation for nested levels %>
             <% indent_class = case page.level
                when 0 then ""
@@ -41,7 +42,12 @@
                 <% end %>
               </div>
               <div class="flex flex-col">
-                <%= link_to page.title, edit_admin_cms_page_path(page), class: "font-medium hover:text-primary" %>
+                <div class="flex items-center gap-2">
+                  <%= link_to page.title, edit_admin_cms_page_path(page), class: "font-medium hover:text-primary" %>
+                  <% if page.archived? %>
+                    <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">Archived</span>
+                  <% end %>
+                </div>
                 <div class="text-xs text-black/60 mt-0.5">
                   <%= page.path %>
                 </div>
@@ -53,6 +59,16 @@
         <% table.column("Last Updated", width: "18%") { |page| render Panda::Core::Admin::UserActivityComponent.new(at: page.last_updated_at) } %>
       <% end %>
     </div>
+
+    <% if archived_count > 0 %>
+      <div class="px-6 pb-4">
+        <% if show_archived %>
+          <%= link_to "Hide archived pages", admin_cms_pages_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <% else %>
+          <%= link_to "Show #{archived_count} archived #{"page".pluralize(archived_count)}", admin_cms_pages_path(show_archived: "true"), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <% end %>
+      </div>
+    <% end %>
   <% else %>
     <div class="p-6">
       <%= render Panda::Core::Admin::CalloutComponent.new(


### PR DESCRIPTION
## Summary
- Add `not_archived` scope to `Panda::CMS::Page` for filtering archived pages from listings
- Update path uniqueness validation to exclude archived pages, allowing path reuse after archiving
- Add archive-aware filtering to admin pages index with show/hide toggle and archived page count
- Archived pages display with reduced opacity and "Archived" badge when visible

## Test plan
- [ ] Verify `not_archived` scope excludes archived pages and includes all other statuses
- [ ] Verify creating a page at a previously-archived path succeeds
- [ ] Verify path uniqueness still blocks duplicates between non-archived pages
- [ ] Verify admin pages index hides archived pages by default
- [ ] Verify "Show N archived pages" toggle reveals archived pages with visual distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)