### PR TITLE
Add drag-and-drop reordering for menu items

### DIFF
--- a/app/javascript/panda/cms/controllers/index.js
+++ b/app/javascript/panda/cms/controllers/index.js
@@ -30,6 +30,7 @@ const cmsControllers = [
   ["page-form", "/panda/cms/controllers/page_form_controller.js"],
   ["nested-form", "/panda/cms/controllers/nested_form_controller.js"],
   ["menu-form", "/panda/cms/controllers/menu_form_controller.js"],
+  ["sortable-list", "/panda/cms/controllers/sortable_list_controller.js"],
   ["editor-form", "/panda/cms/controllers/editor_form_controller.js"],
   ["editor-iframe", "/panda/cms/controllers/editor_iframe_controller.js"],
   ["signature-pad", "/panda/cms/controllers/signature_pad_controller.js"]

--- a/app/javascript/panda/cms/controllers/sortable_list_controller.js
+++ b/app/javascript/panda/cms/controllers/sortable_list_controller.js
@@ -18,24 +18,45 @@ export default class extends Controller {
     }
   }
 
-  // Called by Stimulus when a new item target appears in the DOM
   itemTargetConnected(item) {
     this.setupDragEvents(item)
     this.updatePositions()
+  }
+
+  itemTargetDisconnected(item) {
+    const handlers = item._sortableHandlers
+    if (!handlers) return
+
+    handlers.handle.removeEventListener("mousedown", handlers.onMouseDown)
+    item.removeEventListener("dragstart", handlers.onDragStart)
+    item.removeEventListener("dragover", handlers.onDragOver)
+    item.removeEventListener("dragend", handlers.onDragEnd)
+    item.removeEventListener("drop", handlers.onDrop)
+    delete item._sortableHandlers
   }
 
   setupDragEvents(item) {
     const handle = item.querySelector("[data-sortable-handle]")
     if (!handle) return
 
-    handle.addEventListener("mousedown", () => {
+    const onMouseDown = () => {
       item.setAttribute("draggable", "true")
-    })
+      document.addEventListener("mouseup", () => {
+        if (!this.dragItem) item.removeAttribute("draggable")
+      }, { once: true })
+    }
+    const onDragStart = (e) => this.onDragStart(e, item)
+    const onDragOver = (e) => this.onDragOver(e)
+    const onDragEnd = (e) => this.onDragEnd(e, item)
+    const onDrop = (e) => e.preventDefault()
 
-    item.addEventListener("dragstart", (e) => this.onDragStart(e, item))
-    item.addEventListener("dragover", (e) => this.onDragOver(e))
-    item.addEventListener("dragend", (e) => this.onDragEnd(e, item))
-    item.addEventListener("drop", (e) => e.preventDefault())
+    handle.addEventListener("mousedown", onMouseDown)
+    item.addEventListener("dragstart", onDragStart)
+    item.addEventListener("dragover", onDragOver)
+    item.addEventListener("dragend", onDragEnd)
+    item.addEventListener("drop", onDrop)
+
+    item._sortableHandlers = { handle, onMouseDown, onDragStart, onDragOver, onDragEnd, onDrop }
   }
 
   onDragStart(event, item) {

--- a/app/javascript/panda/cms/controllers/sortable_list_controller.js
+++ b/app/javascript/panda/cms/controllers/sortable_list_controller.js
@@ -1,0 +1,88 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["item"]
+
+  connect() {
+    this.dragItem = null
+    this.form = this.element.closest("form")
+    if (this.form) {
+      this.boundUpdatePositions = this.updatePositions.bind(this)
+      this.form.addEventListener("submit", this.boundUpdatePositions)
+    }
+  }
+
+  disconnect() {
+    if (this.form && this.boundUpdatePositions) {
+      this.form.removeEventListener("submit", this.boundUpdatePositions)
+    }
+  }
+
+  // Called by Stimulus when a new item target appears in the DOM
+  itemTargetConnected(item) {
+    this.setupDragEvents(item)
+    this.updatePositions()
+  }
+
+  setupDragEvents(item) {
+    const handle = item.querySelector("[data-sortable-handle]")
+    if (!handle) return
+
+    handle.addEventListener("mousedown", () => {
+      item.setAttribute("draggable", "true")
+    })
+
+    item.addEventListener("dragstart", (e) => this.onDragStart(e, item))
+    item.addEventListener("dragover", (e) => this.onDragOver(e))
+    item.addEventListener("dragend", (e) => this.onDragEnd(e, item))
+    item.addEventListener("drop", (e) => e.preventDefault())
+  }
+
+  onDragStart(event, item) {
+    this.dragItem = item
+    event.dataTransfer.effectAllowed = "move"
+    event.dataTransfer.setData("text/plain", "")
+
+    requestAnimationFrame(() => {
+      item.classList.add("opacity-50", "border-dashed", "border-blue-300")
+    })
+  }
+
+  onDragOver(event) {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "move"
+    if (!this.dragItem) return
+
+    const target = event.target.closest("[data-sortable-list-target='item']")
+    if (!target || target === this.dragItem || target.style.display === "none") return
+
+    const rect = target.getBoundingClientRect()
+    const midY = rect.top + rect.height / 2
+
+    if (event.clientY < midY) {
+      target.parentNode.insertBefore(this.dragItem, target)
+    } else {
+      target.parentNode.insertBefore(this.dragItem, target.nextSibling)
+    }
+  }
+
+  onDragEnd(event, item) {
+    item.classList.remove("opacity-50", "border-dashed", "border-blue-300")
+    item.removeAttribute("draggable")
+    this.dragItem = null
+    this.updatePositions()
+  }
+
+  updatePositions() {
+    let position = 0
+    this.itemTargets.forEach((item) => {
+      if (item.style.display === "none") return
+
+      const positionInput = item.querySelector("input[name*='[position]']")
+      if (positionInput) {
+        positionInput.value = position
+        position++
+      }
+    })
+  }
+}

--- a/app/models/panda/cms/menu_item.rb
+++ b/app/models/panda/cms/menu_item.rb
@@ -7,6 +7,8 @@ module Panda
     class MenuItem < ApplicationRecord
       acts_as_nested_set scope: [:panda_cms_menu_id], counter_cache: :children_count
 
+      attr_accessor :position
+
       self.implicit_order_column = "lft"
       self.table_name = "panda_cms_menu_items"
 

--- a/app/views/panda/cms/admin/menus/_menu_item_fields.html.erb
+++ b/app/views/panda/cms/admin/menus/_menu_item_fields.html.erb
@@ -1,26 +1,33 @@
 <div class="nested-form-wrapper rounded-2xl border border-gray-200 bg-white mb-4"
      data-controller="collapsible-item"
+     data-sortable-list-target="item"
      data-collapsible-item-expanded-value="<%= form.object.new_record? %>"
      data-new-record="<%= form.object.new_record? %>">
-  <%# Header (always visible, clickable) %>
-  <div class="flex items-center justify-between px-4 py-3 cursor-pointer"
-       data-action="click->collapsible-item#toggle">
-    <div class="flex items-center gap-2">
-      <span class="cursor-grab text-gray-400">::</span>
+  <%# Header (always visible) %>
+  <div class="flex items-center px-4 py-3">
+    <%# Drag handle (separate from toggle) %>
+    <div class="flex items-center justify-center pr-3 cursor-grab text-gray-400 hover:text-gray-600"
+         data-sortable-handle>
+      <i class="fa-solid fa-grip-vertical"></i>
+    </div>
+
+    <%# Toggle area %>
+    <div class="flex-1 flex items-center justify-between cursor-pointer"
+         data-action="click->collapsible-item#toggle">
       <span class="text-sm font-medium text-gray-700"
             data-collapsible-item-target="summary"
             data-placeholder="New item">
         <%= form.object.text.presence || "New item" %>
       </span>
-    </div>
-    <div class="flex items-center gap-3">
-      <button type="button"
-              class="text-xs text-red-500 hover:text-red-700"
-              data-action="click->nested-form#remove click:stop->collapsible-item#noop">
-        <i class="fa-solid fa-trash mr-1"></i> Remove
-      </button>
-      <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform duration-200"
-         data-collapsible-item-target="icon"></i>
+      <div class="flex items-center gap-3">
+        <button type="button"
+                class="text-xs text-red-500 hover:text-red-700"
+                data-action="click->nested-form#remove click:stop->collapsible-item#noop">
+          <i class="fa-solid fa-trash mr-1"></i> Remove
+        </button>
+        <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform duration-200"
+           data-collapsible-item-target="icon"></i>
+      </div>
     </div>
   </div>
 
@@ -28,6 +35,7 @@
   <div class="overflow-hidden transition-all duration-200 ease-out"
        data-collapsible-item-target="body">
     <div class="px-4 pb-4 space-y-4">
+      <%= form.hidden_field :position %>
       <%= form.text_field :text, label: "Menu Item Text", data: { action: "input->collapsible-item#updateSummary" } %>
       <%= form.collection_select :panda_cms_page_id, Panda::CMS::Page.order(:title), :id, :title, { include_blank: "Select a page (optional)", label: "Page" }, { class: "mt-1" } %>
       <%= form.text_field :external_url, label: "External URL (optional)" %>

--- a/app/views/panda/cms/admin/menus/edit.html.erb
+++ b/app/views/panda/cms/admin/menus/edit.html.erb
@@ -21,7 +21,7 @@
     <% if @menu.kind == "static" %>
       <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
         <% panel.with_heading_slot { "Menu Items" } %>
-        <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
+        <div data-controller="nested-form sortable-list" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
           <template data-nested-form-target="template">
             <%= f.fields_for :menu_items, Panda::CMS::MenuItem.new, child_index: "NEW_RECORD" do |item_form| %>
               <%= render "menu_item_fields", form: item_form %>
@@ -34,9 +34,8 @@
                 <%= render "menu_item_fields", form: item_form %>
               <% end %>
             <% end %>
+            <div data-nested-form-target="target"></div>
           </div>
-
-          <div data-nested-form-target="target"></div>
 
           <div class="mt-4">
             <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Menu Item", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>

--- a/app/views/panda/cms/admin/menus/new.html.erb
+++ b/app/views/panda/cms/admin/menus/new.html.erb
@@ -21,16 +21,16 @@
     <div data-menu-form-target="menuItemsSection">
       <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
         <% panel.with_heading_slot { "Menu Items" } %>
-        <div data-controller="nested-form" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
+        <div data-controller="nested-form sortable-list" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
           <template data-nested-form-target="template">
             <%= f.fields_for :menu_items, Panda::CMS::MenuItem.new, child_index: "NEW_RECORD" do |item_form| %>
               <%= render "menu_item_fields", form: item_form %>
             <% end %>
           </template>
 
-          <div class="space-y-4"></div>
-
-          <div data-nested-form-target="target"></div>
+          <div class="space-y-4">
+            <div data-nested-form-target="target"></div>
+          </div>
 
           <div class="mt-4">
             <%= render Panda::Core::Admin::ButtonComponent.new(text: "Add Menu Item", action: :add, link: "#", size: :small, data: { action: "click->nested-form#add" }) %>

--- a/spec/requests/panda/cms/admin/menus_controller_spec.rb
+++ b/spec/requests/panda/cms/admin/menus_controller_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin Menus - Reordering", type: :request do
+  fixtures :panda_cms_menus, :panda_cms_menu_items, :panda_cms_pages
+
+  let(:admin_user) { create_admin_user }
+  let(:main_menu) { panda_cms_menus(:main_menu) }
+  let(:home_item) { panda_cms_menu_items(:home_link) }
+  let(:about_item) { panda_cms_menu_items(:about_link) }
+  let(:services_item) { panda_cms_menu_items(:services_link) }
+
+  before do
+    post "/admin/test_sessions", params: {user_id: admin_user.id}
+  end
+
+  describe "PATCH /admin/cms/menus/:id - reordering" do
+    it "reorders existing menu items based on position params" do
+      # Original order: Home(lft:1), About(lft:3), Services(lft:5)
+      # Desired order: Services, Home, About
+      patch "/admin/cms/menus/#{main_menu.id}", params: {
+        menu: {
+          name: main_menu.name,
+          kind: main_menu.kind,
+          menu_items_attributes: {
+            "0" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "0"},
+            "1" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "1"},
+            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "2"}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
+      expect(reordered).to eq(["Services", "Home", "About"])
+    end
+
+    it "preserves order when positions match current order" do
+      # Submit in the same order as current: Home, About, Services
+      patch "/admin/cms/menus/#{main_menu.id}", params: {
+        menu: {
+          name: main_menu.name,
+          kind: main_menu.kind,
+          menu_items_attributes: {
+            "0" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "0"},
+            "1" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "1"},
+            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
+      expect(reordered).to eq(["Home", "About", "Services"])
+    end
+
+    it "handles reorder with a destroyed item" do
+      # Destroy About, reorder: Services, Home
+      patch "/admin/cms/menus/#{main_menu.id}", params: {
+        menu: {
+          name: main_menu.name,
+          kind: main_menu.kind,
+          menu_items_attributes: {
+            "0" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "0"},
+            "1" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "1"},
+            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, _destroy: "1"}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
+      expect(reordered).to eq(["Services", "Home"])
+    end
+
+    it "skips reorder when no position params are present" do
+      patch "/admin/cms/menus/#{main_menu.id}", params: {
+        menu: {
+          name: "Renamed Menu",
+          kind: main_menu.kind,
+          menu_items_attributes: {
+            "0" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id},
+            "1" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
+      expect(reordered).to eq(["Home", "About", "Services"])
+    end
+  end
+
+  describe "POST /admin/cms/menus - create with reordering" do
+    it "creates a menu and reorders items by position" do
+      homepage = panda_cms_pages(:homepage)
+      about_page = panda_cms_pages(:about_page)
+
+      post "/admin/cms/menus", params: {
+        menu: {
+          name: "New Ordered Menu",
+          kind: "static",
+          menu_items_attributes: {
+            "1000" => {text: "Second Link", panda_cms_page_id: about_page.id, position: "1"},
+            "2000" => {text: "First Link", panda_cms_page_id: homepage.id, position: "0"}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      new_menu = Panda::CMS::Menu.find_by(name: "New Ordered Menu")
+      ordered = new_menu.menu_items.order(:lft).pluck(:text)
+      expect(ordered).to eq(["First Link", "Second Link"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Static menu items can now be reordered by dragging the grip handle next to each item
- On save, the new order is applied using awesome_nested_set's `move_to_right_of` method (no direct lft/rgt manipulation)
- Replaced the `::` text with a proper `fa-grip-vertical` icon as the drag handle, separated from the collapsible toggle area

## Changes
- **New**: `sortable_list_controller.js` — Stimulus controller using HTML5 Drag and Drop API
- **Updated**: Menu item partial — restructured header, added position hidden field and sortable targets
- **Updated**: Menu views (edit + new) — wired up sortable-list controller, moved nested-form target inside container
- **Updated**: MenuItem model — added transient `position` attr_accessor for form communication
- **Updated**: MenusController — reorders items after create/update using `move_to_right_of`

## Test plan
- [x] All 105 existing menu tests pass
- [x] StandardRB, Brakeman, ERB lint, bundle-audit all clean
- [ ] Manual: Edit a static menu, drag items to reorder, save, verify order persists
- [ ] Manual: Create a new menu with items, reorder before saving, verify order
- [ ] Manual: Add new items to existing menu and drag between existing items

🤖 Generated with [Claude Code](https://claude.com/claude-code)