### PR TITLE
feat: Add show_all_items option to PageMenuComponent

### DIFF
--- a/app/components/panda/cms/menu_component.html.erb
+++ b/app/components/panda/cms/menu_component.html.erb
@@ -7,7 +7,8 @@
         page: menu_item.page,
         start_depth: 1,
         styles: page_menu_styles,
-        show_heading: false
+        show_heading: false,
+        show_all_items: page_menu_show_all_items
       ) %>
     <% end %>
   <% end %>

--- a/app/components/panda/cms/menu_component.rb
+++ b/app/components/panda/cms/menu_component.rb
@@ -9,16 +9,18 @@ module Panda
     # @param overrides [Hash] Menu item overrides - supports :hidden_items array to hide specific menu items by text
     # @param render_page_menu [Boolean] Whether to render sub-page menus
     # @param page_menu_styles [Hash] Styles for the page menu component
+    # @param page_menu_show_all_items [Boolean] When true, page menus show all descendants (disables depth filtering)
     class MenuComponent < Panda::Core::Base
-      attr_reader :name, :current_path, :styles, :overrides, :render_page_menu, :page_menu_styles
+      attr_reader :name, :current_path, :styles, :overrides, :render_page_menu, :page_menu_styles, :page_menu_show_all_items
 
-      def initialize(name:, current_path: "", styles: {}, overrides: {}, render_page_menu: false, page_menu_styles: {}, **attrs)
+      def initialize(name:, current_path: "", styles: {}, overrides: {}, render_page_menu: false, page_menu_styles: {}, page_menu_show_all_items: false, **attrs)
         @name = name
         @current_path = current_path
         @styles = styles.freeze
         @overrides = overrides.freeze
         @render_page_menu = render_page_menu
         @page_menu_styles = page_menu_styles.freeze
+        @page_menu_show_all_items = page_menu_show_all_items
         super(**attrs)
       end
 

--- a/app/components/panda/cms/page_menu_component.rb
+++ b/app/components/panda/cms/page_menu_component.rb
@@ -95,12 +95,15 @@ module Panda
         # Skip if path contains parameter placeholder
         return true if submenu_item.page&.path&.include?(":")
 
-        # Skip if page is nil or Current.page is nil
-        return true if submenu_item&.page.nil? || Panda::CMS::Current.page.nil?
+        # Always skip items without an associated page
+        return true if submenu_item&.page.nil?
 
         # When show_all_items is enabled, skip depth-based filtering
         # (used by mobile menus that need the full tree for JS-driven collapsing)
         return false if @show_all_items
+
+        # From here on, we rely on Current.page being present for depth-based logic
+        return true if Panda::CMS::Current.page.nil?
 
         # Skip if we're on the top menu item and level > 1
         return true if Panda::CMS::Current.page == @menu_item.page && level > 1

--- a/app/components/panda/cms/page_menu_component.rb
+++ b/app/components/panda/cms/page_menu_component.rb
@@ -7,14 +7,16 @@ module Panda
     # @param start_depth [Integer] The depth level to start the menu from
     # @param styles [Hash] CSS classes for styling menu elements
     # @param show_heading [Boolean] Whether to show the top-level heading
+    # @param show_all_items [Boolean] When true, disables depth-based filtering so all descendants are shown
     class PageMenuComponent < Panda::Core::Base
-      attr_reader :page, :start_depth, :styles, :show_heading
+      attr_reader :page, :start_depth, :styles, :show_heading, :show_all_items
 
-      def initialize(page:, start_depth:, styles: {}, show_heading: true, **attrs)
+      def initialize(page:, start_depth:, styles: {}, show_heading: true, show_all_items: false, **attrs)
         @page = page
         @start_depth = start_depth
         @styles = styles.freeze
         @show_heading = show_heading
+        @show_all_items = show_all_items
         super(**attrs)
       end
 
@@ -90,14 +92,18 @@ module Panda
       end
 
       def should_skip_item?(submenu_item, level)
-        # Skip if we're on the top menu item and level > 1
-        return true if Panda::CMS::Current.page == @menu_item.page && level > 1
-
         # Skip if path contains parameter placeholder
         return true if submenu_item.page&.path&.include?(":")
 
         # Skip if page is nil or Current.page is nil
         return true if submenu_item&.page.nil? || Panda::CMS::Current.page.nil?
+
+        # When show_all_items is enabled, skip depth-based filtering
+        # (used by mobile menus that need the full tree for JS-driven collapsing)
+        return false if @show_all_items
+
+        # Skip if we're on the top menu item and level > 1
+        return true if Panda::CMS::Current.page == @menu_item.page && level > 1
 
         # Skip if submenu page is deeper than current page and not an ancestor
         submenu_item.page.depth.to_i > Panda::CMS::Current.page.depth.to_i &&

--- a/spec/components/panda/cms/menu_component_spec.rb
+++ b/spec/components/panda/cms/menu_component_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Panda::CMS::MenuComponent, type: :component do
       component = described_class.new(name: "Main Menu", page_menu_styles: page_menu_styles)
       expect(component.page_menu_styles).to eq(page_menu_styles)
     end
+
+    it "defaults page_menu_show_all_items to false" do
+      component = described_class.new(name: "Main Menu")
+      expect(component.page_menu_show_all_items).to be false
+    end
+
+    it "accepts page_menu_show_all_items parameter" do
+      component = described_class.new(name: "Main Menu", page_menu_show_all_items: true)
+      expect(component.page_menu_show_all_items).to be true
+    end
   end
 
   describe "#processed_menu_items" do

--- a/spec/components/panda/cms/page_menu_component_spec.rb
+++ b/spec/components/panda/cms/page_menu_component_spec.rb
@@ -27,6 +27,48 @@ RSpec.describe Panda::CMS::PageMenuComponent, type: :component do
     end
   end
 
+  describe "initialization of show_all_items" do
+    let(:page) { panda_cms_pages(:homepage) }
+
+    it "defaults show_all_items to false" do
+      component = described_class.new(page: page, start_depth: 1, styles: {})
+      expect(component.show_all_items).to be false
+    end
+
+    it "accepts show_all_items parameter" do
+      component = described_class.new(page: page, start_depth: 1, styles: {}, show_all_items: true)
+      expect(component.show_all_items).to be true
+    end
+  end
+
+  describe "should_skip_item? with show_all_items" do
+    let(:about_page) { panda_cms_pages(:about_page) }
+    let(:team_page) { panda_cms_pages(:about_team_page) }
+
+    it "skips items without a page regardless of show_all_items" do
+      component = described_class.new(page: about_page, start_depth: 1, styles: {}, show_all_items: true)
+      menu_item = instance_double(Panda::CMS::MenuItem, page: nil)
+
+      expect(component.send(:should_skip_item?, menu_item, 1)).to be true
+    end
+
+    it "does not skip items when show_all_items is true and Current.page is nil" do
+      allow(Panda::CMS::Current).to receive(:page).and_return(nil)
+      component = described_class.new(page: about_page, start_depth: 1, styles: {}, show_all_items: true)
+      menu_item = instance_double(Panda::CMS::MenuItem, page: team_page)
+
+      expect(component.send(:should_skip_item?, menu_item, 1)).to be false
+    end
+
+    it "skips items when show_all_items is false and Current.page is nil" do
+      allow(Panda::CMS::Current).to receive(:page).and_return(nil)
+      component = described_class.new(page: about_page, start_depth: 1, styles: {})
+      menu_item = instance_double(Panda::CMS::MenuItem, page: team_page)
+
+      expect(component.send(:should_skip_item?, menu_item, 1)).to be true
+    end
+  end
+
   describe "rendering" do
     let(:page) { panda_cms_pages(:homepage) }
 


### PR DESCRIPTION
## Summary
- Adds `show_all_items` parameter to `PageMenuComponent` that disables depth-based filtering, so all descendant pages are rendered regardless of the current page's depth
- Passes through `MenuComponent` via new `page_menu_show_all_items` parameter
- Needed for mobile menus where the full page tree should render so JavaScript can handle expand/collapse with chevrons

## Context
When `PageMenuComponent` is used inside a full-site mobile menu (via `MenuComponent` with `render_page_menu: true`), the `should_skip_item?` method filters out items from other sections based on the current page's depth. This causes page menus for sections like "About Us" to render empty `<nav>` elements when the user is browsing an "Advice Hub" page — the chevron toggle buttons exist but expand nothing.

## Test plan
- [ ] Verify existing sidebar page menus still filter correctly (default `show_all_items: false`)
- [ ] Verify that `show_all_items: true` renders all descendants without depth filtering
- [ ] Run existing specs: `bundle exec rspec spec/components/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)