### PR TITLE
fix: Rename SQL alias to avoid collision with Post#month method

### DIFF
--- a/app/helpers/panda/cms/posts_helper.rb
+++ b/app/helpers/panda/cms/posts_helper.rb
@@ -13,13 +13,13 @@ module Panda
           Panda::CMS::Post
             .where(status: :published)
             .select(
-              Arel.sql("DATE_TRUNC('month', published_at) as month"),
+              Arel.sql("DATE_TRUNC('month', published_at) as month_date"),
               Arel.sql("COUNT(*) as post_count")
             )
             .group(Arel.sql("DATE_TRUNC('month', published_at)"))
             .order(Arel.sql("DATE_TRUNC('month', published_at) DESC"))
             .map do |result|
-              date = result.month
+              date = result.month_date
               {
                 year: date.strftime("%Y"),
                 month: date.strftime("%m"),


### PR DESCRIPTION
## Summary

- `/news-and-updates` returns 500 on staging due to `ActiveModel::MissingAttributeError (missing attribute 'slug' for Panda::CMS::Post)`
- The `posts_months_menu` helper uses `.select("DATE_TRUNC('month', published_at) as month")` — the `month` alias collides with the `Post#month` instance method, which accesses `slug` (not in the SELECT)
- Renamed the SQL alias from `month` to `month_date` to avoid the collision

## Root cause

`Post#month` (defined on line 92 of `post.rb`) overrides the dynamically generated attribute accessor for the SQL alias, so `result.month` calls the model method instead of reading the SQL result column.

## Test plan

- [x] All panda-cms helper specs pass
- [x] Brakeman, StandardRB, ERBLint, Zeitwerk all pass
- [ ] Verify `/news-and-updates` loads on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)