### PR TITLE
feat: Menu ordering options and page reordering

### DIFF
--- a/app/controllers/panda/cms/admin/menus_controller.rb
+++ b/app/controllers/panda/cms/admin/menus_controller.rb
@@ -43,7 +43,11 @@ module Panda
         # @type PATCH/PUT
         def update
           if @menu.update(menu_params_with_defaults)
-            reorder_menu_items(@menu)
+            if @menu.ordering == "default"
+              reorder_menu_items(@menu)
+            else
+              @menu.apply_ordering_to_static_items!
+            end
             redirect_to admin_cms_menus_path, notice: "Menu was successfully updated.", status: :see_other
           else
             render :edit, status: :unprocessable_entity
@@ -75,7 +79,7 @@ module Panda
         end
 
         def menu_params
-          params.require(:menu).permit(:name, :kind, :start_page_id, :promote_active_item, menu_items_attributes: [:id, :text, :external_url, :panda_cms_page_id, :position, :_destroy])
+          params.require(:menu).permit(:name, :kind, :start_page_id, :promote_active_item, :ordering, menu_items_attributes: [:id, :text, :external_url, :panda_cms_page_id, :position, :_destroy])
         end
 
         def menu_params_with_defaults

--- a/app/controllers/panda/cms/admin/pages_controller.rb
+++ b/app/controllers/panda/cms/admin/pages_controller.rb
@@ -64,6 +64,31 @@ module Panda
           end
         end
 
+        # Reorder a page relative to a sibling
+        # @type POST
+        def reorder
+          target = Panda::CMS::Page.find(params[:target_id])
+
+          unless page.parent_id == target.parent_id
+            return render json: {error: "Can only reorder siblings"}, status: :unprocessable_entity
+          end
+
+          case params[:position]
+          when "before"
+            page.move_to_left_of(target)
+          when "after"
+            page.move_to_right_of(target)
+          else
+            return render json: {error: "Invalid position"}, status: :unprocessable_entity
+          end
+
+          # Regenerate auto menus that include these pages
+          ancestor_ids = page.self_and_ancestors.pluck(:id)
+          Panda::CMS::Menu.where(kind: "auto", start_page_id: ancestor_ids).find_each(&:generate_auto_menu_items)
+
+          render json: {success: true}
+        end
+
         # @type PATCH/PUT
         # @return
         def update

--- a/app/javascript/panda/cms/controllers/index.js
+++ b/app/javascript/panda/cms/controllers/index.js
@@ -31,6 +31,7 @@ const cmsControllers = [
   ["nested-form", "/panda/cms/controllers/nested_form_controller.js"],
   ["menu-form", "/panda/cms/controllers/menu_form_controller.js"],
   ["sortable-list", "/panda/cms/controllers/sortable_list_controller.js"],
+  ["sortable-tree", "/panda/cms/controllers/sortable_tree_controller.js"],
   ["datetime", "/panda/cms/controllers/datetime_controller.js"],
   ["editor-form", "/panda/cms/controllers/editor_form_controller.js"],
   ["editor-iframe", "/panda/cms/controllers/editor_iframe_controller.js"],

--- a/app/javascript/panda/cms/controllers/menu_form_controller.js
+++ b/app/javascript/panda/cms/controllers/menu_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["startPageField", "menuItemsSection"]
+  static targets = ["startPageField", "menuItemsSection", "orderingField", "dragHandles"]
 
   connect() {
     console.log("Menu form controller connected")
@@ -12,6 +12,10 @@ export default class extends Controller {
   kindChanged(event) {
     console.log("[menu-form] kindChanged called", event)
     this.updateFieldsVisibility()
+  }
+
+  orderingChanged() {
+    this.updateDragHandleVisibility()
   }
 
   updateFieldsVisibility() {
@@ -28,7 +32,7 @@ export default class extends Controller {
     console.log("[menu-form] selectedKind:", selectedKind)
 
     if (selectedKind === "auto") {
-      // Show start page field, hide menu items section
+      // Show start page field, hide menu items section and ordering
       console.log("[menu-form] AUTO - Showing start page field")
       if (this.hasStartPageFieldTarget) {
         console.log("[menu-form] Removing hidden from start page field")
@@ -39,8 +43,11 @@ export default class extends Controller {
       if (this.hasMenuItemsSectionTarget) {
         this.menuItemsSectionTarget.classList.add("hidden")
       }
+      if (this.hasOrderingFieldTarget) {
+        this.orderingFieldTarget.classList.add("hidden")
+      }
     } else {
-      // Hide start page field, show menu items section
+      // Hide start page field, show menu items section and ordering
       console.log("[menu-form] STATIC - Hiding start page field")
       if (this.hasStartPageFieldTarget) {
         this.startPageFieldTarget.classList.add("hidden")
@@ -48,6 +55,23 @@ export default class extends Controller {
       if (this.hasMenuItemsSectionTarget) {
         this.menuItemsSectionTarget.classList.remove("hidden")
       }
+      if (this.hasOrderingFieldTarget) {
+        this.orderingFieldTarget.classList.remove("hidden")
+      }
     }
+
+    this.updateDragHandleVisibility()
+  }
+
+  updateDragHandleVisibility() {
+    if (!this.hasDragHandlesTarget) return
+
+    const orderingSelect = this.element.querySelector('select[name*="[ordering]"]')
+    const ordering = orderingSelect ? orderingSelect.value : "default"
+
+    const handles = this.dragHandlesTarget.querySelectorAll("[data-sortable-handle]")
+    handles.forEach(handle => {
+      handle.style.display = ordering === "default" ? "" : "none"
+    })
   }
 }

--- a/app/javascript/panda/cms/controllers/sortable_list_controller.js
+++ b/app/javascript/panda/cms/controllers/sortable_list_controller.js
@@ -39,7 +39,8 @@ export default class extends Controller {
     const handle = item.querySelector("[data-sortable-handle]")
     if (!handle) return
 
-    const onMouseDown = () => {
+    const onMouseDown = (e) => {
+      e.stopPropagation()
       item.setAttribute("draggable", "true")
       document.addEventListener("mouseup", () => {
         if (!this.dragItem) item.removeAttribute("draggable")

--- a/app/javascript/panda/cms/controllers/sortable_tree_controller.js
+++ b/app/javascript/panda/cms/controllers/sortable_tree_controller.js
@@ -1,0 +1,154 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["row"]
+  static values = { reorderUrl: String }
+
+  connect() {
+    this.dragItem = null
+    this.dropIndicator = null
+    this.setupDragEvents()
+  }
+
+  disconnect() {
+    this.removeDropIndicator()
+  }
+
+  setupDragEvents() {
+    this.rowTargets.forEach(row => this.setupRowDrag(row))
+  }
+
+  rowTargetConnected(row) {
+    this.setupRowDrag(row)
+  }
+
+  setupRowDrag(row) {
+    const handle = row.querySelector("[data-sortable-tree-handle]")
+    if (!handle) return
+
+    const tableRow = row.closest(".table-row")
+    if (!tableRow) return
+
+    const onMouseDown = (e) => {
+      e.stopPropagation()
+      tableRow.setAttribute("draggable", "true")
+      document.addEventListener("mouseup", () => {
+        if (!this.dragItem) tableRow.removeAttribute("draggable")
+      }, { once: true })
+    }
+
+    const onDragStart = (e) => {
+      this.dragItem = row
+      this.dragTableRow = tableRow
+      e.dataTransfer.effectAllowed = "move"
+      e.dataTransfer.setData("text/plain", "")
+
+      requestAnimationFrame(() => {
+        tableRow.classList.add("opacity-50")
+      })
+    }
+
+    const onDragEnd = () => {
+      if (this.dragTableRow) {
+        this.dragTableRow.classList.remove("opacity-50")
+        this.dragTableRow.removeAttribute("draggable")
+      }
+      this.dragItem = null
+      this.dragTableRow = null
+      this.removeDropIndicator()
+    }
+
+    handle.addEventListener("mousedown", onMouseDown)
+    tableRow.addEventListener("dragstart", onDragStart)
+    tableRow.addEventListener("dragend", onDragEnd)
+    tableRow.addEventListener("dragover", (e) => this.onDragOver(e, row, tableRow))
+    tableRow.addEventListener("drop", (e) => this.onDrop(e, row))
+  }
+
+  onDragOver(event, targetRow, targetTableRow) {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "move"
+    if (!this.dragItem || targetRow === this.dragItem) {
+      this.removeDropIndicator()
+      return
+    }
+
+    // Only allow reordering between siblings (same parent, same level)
+    if (targetRow.dataset.parentId !== this.dragItem.dataset.parentId) {
+      this.removeDropIndicator()
+      return
+    }
+
+    const rect = targetTableRow.getBoundingClientRect()
+    const midY = rect.top + rect.height / 2
+    const position = event.clientY < midY ? "before" : "after"
+
+    this.showDropIndicator(targetTableRow, position)
+  }
+
+  onDrop(event, targetRow) {
+    event.preventDefault()
+    if (!this.dragItem || targetRow === this.dragItem) return
+    if (targetRow.dataset.parentId !== this.dragItem.dataset.parentId) return
+
+    const targetTableRow = targetRow.closest(".table-row")
+    if (!targetTableRow) return
+
+    const rect = targetTableRow.getBoundingClientRect()
+    const midY = rect.top + rect.height / 2
+    const position = event.clientY < midY ? "before" : "after"
+
+    const pageId = this.dragItem.dataset.pageId
+    const targetId = targetRow.dataset.pageId
+    const url = this.reorderUrlValue.replace("__PAGE_ID__", pageId)
+
+    this.removeDropIndicator()
+
+    // Move in DOM immediately for visual feedback
+    if (position === "before") {
+      targetTableRow.parentNode.insertBefore(this.dragTableRow, targetTableRow)
+    } else {
+      targetTableRow.parentNode.insertBefore(this.dragTableRow, targetTableRow.nextSibling)
+    }
+
+    // Send to server
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+    fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken,
+        "Accept": "application/json"
+      },
+      body: JSON.stringify({ target_id: targetId, position: position })
+    }).then(response => {
+      if (!response.ok) {
+        // Reload to restore correct order on failure
+        window.location.reload()
+      }
+    }).catch(() => {
+      window.location.reload()
+    })
+  }
+
+  showDropIndicator(targetTableRow, position) {
+    this.removeDropIndicator()
+
+    this.dropIndicator = document.createElement("div")
+    this.dropIndicator.className = "h-0.5 bg-blue-500 rounded-full mx-2"
+    this.dropIndicator.style.pointerEvents = "none"
+
+    if (position === "before") {
+      targetTableRow.parentNode.insertBefore(this.dropIndicator, targetTableRow)
+    } else {
+      targetTableRow.parentNode.insertBefore(this.dropIndicator, targetTableRow.nextSibling)
+    }
+  }
+
+  removeDropIndicator() {
+    if (this.dropIndicator) {
+      this.dropIndicator.remove()
+      this.dropIndicator = null
+    }
+  }
+}

--- a/app/models/panda/cms/menu.rb
+++ b/app/models/panda/cms/menu.rb
@@ -23,7 +23,7 @@ module Panda
 
       validates :name, presence: true, uniqueness: {case_sensitive: false}
       validates :kind, presence: true, inclusion: {in: %w[static auto]}
-      validates :ordering, inclusion: {in: %w[default alphabetical]}
+      validates :ordering, inclusion: {in: %w[default alphabetical reverse_alphabetical page_order]}
       validate :validate_start_page
 
       def generate_auto_menu_items
@@ -43,6 +43,29 @@ module Panda
         # Uses update_column to avoid re-triggering after_save callbacks.
         update_column(:updated_at, Time.current)
         clear_menu_cache
+      end
+
+      def apply_ordering_to_static_items!
+        return if kind != "static" || ordering == "default"
+
+        items = menu_items.reload.to_a
+        return if items.size < 2
+
+        sorted = case ordering
+        when "alphabetical"
+          items.sort_by { |item| item.text.downcase }
+        when "reverse_alphabetical"
+          items.sort_by { |item| item.text.downcase }.reverse
+        when "page_order"
+          # Items with pages sort by page tree position (lft); items without pages go to the end
+          items.sort_by { |item| item.page&.lft || Float::INFINITY }
+        else
+          return
+        end
+
+        sorted.each_cons(2) do |left_item, right_item|
+          right_item.reload.move_to_right_of(left_item.reload)
+        end
       end
 
       def page_pinned?(page_id)
@@ -75,6 +98,10 @@ module Panda
         ordered = case ordering
         when "alphabetical"
           pages.reorder(:title)
+        when "reverse_alphabetical"
+          pages.reorder(title: :desc)
+        when "page_order"
+          pages # Page order uses nested set order (lft), same as default
         else
           pages # Default uses nested set order (lft)
         end

--- a/app/views/panda/cms/admin/menus/edit.html.erb
+++ b/app/views/panda/cms/admin/menus/edit.html.erb
@@ -15,13 +15,27 @@
         </div>
 
         <%= f.check_box :promote_active_item, label: "Promote active item to top" %>
+
+        <% if @menu.kind == "static" %>
+          <div data-menu-form-target="orderingField">
+            <%= f.select :ordering,
+              options_for_select([
+                ["Default (Manual Order)", "default"],
+                ["A-Z", "alphabetical"],
+                ["Z-A", "reverse_alphabetical"],
+                ["Page Order", "page_order"]
+              ], selected: @menu.ordering),
+              {},
+              { "data-action": "change->menu-form#orderingChanged" } %>
+          </div>
+        <% end %>
       </div>
     <% end %>
 
     <% if @menu.kind == "static" %>
       <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
         <% panel.with_heading_slot { "Menu Items" } %>
-        <div data-controller="nested-form sortable-list" data-nested-form-wrapper-selector-value=".nested-form-wrapper">
+        <div data-controller="nested-form sortable-list" data-nested-form-wrapper-selector-value=".nested-form-wrapper" data-menu-form-target="dragHandles">
           <template data-nested-form-target="template">
             <%= f.fields_for :menu_items, Panda::CMS::MenuItem.new, child_index: "NEW_RECORD" do |item_form| %>
               <%= render "menu_item_fields", form: item_form %>

--- a/app/views/panda/cms/admin/menus/new.html.erb
+++ b/app/views/panda/cms/admin/menus/new.html.erb
@@ -15,6 +15,18 @@
         </div>
 
         <%= f.check_box :promote_active_item, label: "Promote active item to top" %>
+
+        <div data-menu-form-target="orderingField">
+          <%= f.select :ordering,
+            options_for_select([
+              ["Default (Manual Order)", "default"],
+              ["A-Z", "alphabetical"],
+              ["Z-A", "reverse_alphabetical"],
+              ["Page Order", "page_order"]
+            ], selected: menu.ordering || "default"),
+            {},
+            { "data-action": "change->menu-form#orderingChanged" } %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/panda/cms/admin/pages/index.html.erb
+++ b/app/views/panda/cms/admin/pages/index.html.erb
@@ -5,10 +5,10 @@
 
   <% if root_page %>
     <% page_rows = show_archived ? root_page.self_and_descendants : root_page.self_and_descendants.not_archived %>
-    <div data-controller="tree" data-tree-target="container" style="opacity: 0; transition: opacity 0.2s;">
+    <div data-controller="tree sortable-tree" data-tree-target="container" data-sortable-tree-reorder-url-value="<%= reorder_admin_cms_page_path("__PAGE_ID__") %>" style="opacity: 0; transition: opacity 0.2s;">
       <%= render Panda::Core::Admin::TableComponent.new(term: "page", rows: page_rows) do |table| %>
         <% table.column("Name") do |page| %>
-          <div class="flex flex-col <%= "opacity-50" if page.archived? %>" data-tree-target="row" data-page-id="<%= page.id %>" data-level="<%= page.level %>" data-parent-id="<%= page.parent_id %>">
+          <div class="flex flex-col <%= "opacity-50" if page.archived? %>" data-tree-target="row" data-sortable-tree-target="row" data-page-id="<%= page.id %>" data-level="<%= page.level %>" data-parent-id="<%= page.parent_id %>">
             <%# Add indentation for nested levels %>
             <% indent_class = case page.level
                when 0 then ""
@@ -20,6 +20,14 @@
                else "pl-28"
                end %>
             <div class="flex items-center gap-2 <%= indent_class %>">
+              <% if page.level > 0 && !page.archived? %>
+                <div class="flex items-center justify-center cursor-grab text-gray-300 hover:text-gray-500"
+                     data-sortable-tree-handle>
+                  <i class="fa-solid fa-grip-vertical text-xs"></i>
+                </div>
+              <% else %>
+                <div class="w-4"></div>
+              <% end %>
               <%# Chevron/icon section - all use w-4 for consistent spacing %>
               <div class="w-4 flex items-center justify-center">
                 <% if page.children_count > 0 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Panda::CMS::Engine.routes.draw do
       end
       resources :pages do
         resources :block_contents, only: %i[update]
+        post :reorder, on: :member
       end
       resources :posts
       resources :redirects, except: :show

--- a/db/migrate/20260301233859_add_ordering_options_to_panda_cms_menus.rb
+++ b/db/migrate/20260301233859_add_ordering_options_to_panda_cms_menus.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddOrderingOptionsToPandaCmsMenus < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<-SQL
+      ALTER TYPE panda_cms_menu_ordering ADD VALUE IF NOT EXISTS 'page_order';
+    SQL
+    execute <<-SQL
+      ALTER TYPE panda_cms_menu_ordering ADD VALUE IF NOT EXISTS 'reverse_alphabetical';
+    SQL
+  end
+
+  def down
+    # PostgreSQL doesn't support removing enum values; recreate if needed
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_26_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -18,7 +18,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_000001) do
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "panda_cms_block_kind", ["plain_text", "rich_text", "image", "video", "audio", "file", "code", "iframe", "quote", "list", "table", "form", "helpdesk_form"]
   create_enum "panda_cms_menu_kind", ["static", "auto"]
-  create_enum "panda_cms_menu_ordering", ["default", "alphabetical"]
+  create_enum "panda_cms_menu_ordering", ["default", "alphabetical", "page_order", "reverse_alphabetical"]
   create_enum "panda_cms_og_type", ["website", "article", "profile", "video", "book"]
   create_enum "panda_cms_page_status", ["published", "unlisted", "hidden", "archived", "pending_review"]
   create_enum "panda_cms_post_status", ["published", "unlisted", "hidden", "archived", "pending_review"]
@@ -100,6 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_000001) do
   create_table "panda_cms_form_fields", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "active", default: true
     t.datetime "created_at", null: false
+    t.boolean "display_on_summary", default: false, null: false
     t.string "field_type", null: false
     t.uuid "form_id", null: false
     t.text "hint"

--- a/spec/models/panda/cms/menu_spec.rb
+++ b/spec/models/panda/cms/menu_spec.rb
@@ -82,6 +82,16 @@ RSpec.describe Panda::CMS::Menu, type: :model do
         expect(menu).to be_valid
       end
 
+      it "is valid with 'reverse_alphabetical' ordering" do
+        menu = Panda::CMS::Menu.new(name: "Test Menu", kind: "static", ordering: "reverse_alphabetical")
+        expect(menu).to be_valid
+      end
+
+      it "is valid with 'page_order' ordering" do
+        menu = Panda::CMS::Menu.new(name: "Test Menu", kind: "static", ordering: "page_order")
+        expect(menu).to be_valid
+      end
+
       it "is invalid with unknown ordering" do
         menu = Panda::CMS::Menu.new(name: "Test Menu", kind: "static", ordering: "invalid")
         expect(menu).not_to be_valid
@@ -420,6 +430,56 @@ RSpec.describe Panda::CMS::Menu, type: :model do
         expect(titles.first).to eq("Gamma")
         expect(menu.reload.pinned_page_ids).to eq([page_c.id.to_s])
       end
+    end
+  end
+
+  describe "#apply_ordering_to_static_items!" do
+    it "does nothing for auto menus" do
+      expect { auto_menu.apply_ordering_to_static_items! }.not_to change { auto_menu.menu_items.reload.order(:lft).pluck(:text) }
+    end
+
+    it "does nothing when ordering is default" do
+      static_menu.update_column(:ordering, "default")
+      expect { static_menu.apply_ordering_to_static_items! }.not_to change { static_menu.menu_items.reload.order(:lft).pluck(:text) }
+    end
+
+    context "alphabetical ordering" do
+      it "sorts menu items alphabetically by text" do
+        # Main menu items: Home(lft:1), About(lft:3), Services(lft:5)
+        static_menu.update_column(:ordering, "alphabetical")
+        static_menu.apply_ordering_to_static_items!
+
+        ordered = static_menu.menu_items.reload.order(:lft).pluck(:text)
+        expect(ordered).to eq(["About", "Home", "Services"])
+      end
+    end
+
+    context "reverse_alphabetical ordering" do
+      it "sorts menu items reverse-alphabetically by text" do
+        static_menu.update_column(:ordering, "reverse_alphabetical")
+        static_menu.apply_ordering_to_static_items!
+
+        ordered = static_menu.menu_items.reload.order(:lft).pluck(:text)
+        expect(ordered).to eq(["Services", "Home", "About"])
+      end
+    end
+
+    context "page_order ordering" do
+      it "sorts menu items by their page's lft position" do
+        # Pages: Homepage(lft:1), About(lft:2), Services(lft:6)
+        # Menu items: Home->Homepage, About->About page, Services->Services page
+        static_menu.update_column(:ordering, "page_order")
+        static_menu.apply_ordering_to_static_items!
+
+        ordered = static_menu.menu_items.reload.order(:lft).pluck(:text)
+        expect(ordered).to eq(["Home", "About", "Services"])
+      end
+    end
+
+    it "handles menus with fewer than 2 items" do
+      menu = panda_cms_menus(:footer_menu) # has 1 item (external_link)
+      menu.update_column(:ordering, "alphabetical")
+      expect { menu.apply_ordering_to_static_items! }.not_to raise_error
     end
   end
 

--- a/spec/requests/panda/cms/admin/menus_controller_spec.rb
+++ b/spec/requests/panda/cms/admin/menus_controller_spec.rb
@@ -96,6 +96,70 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
     end
   end
 
+  describe "PATCH /admin/cms/menus/:id - ordering change" do
+    it "applies alphabetical ordering to static menu items" do
+      # Original order: Home, About, Services
+      patch "/admin/cms/menus/#{main_menu.id}", params: {
+        menu: {
+          name: main_menu.name,
+          kind: main_menu.kind,
+          ordering: "alphabetical",
+          menu_items_attributes: {
+            "0" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "0"},
+            "1" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "1"},
+            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
+      expect(reordered).to eq(["About", "Home", "Services"])
+    end
+
+    it "applies reverse alphabetical ordering to static menu items" do
+      patch "/admin/cms/menus/#{main_menu.id}", params: {
+        menu: {
+          name: main_menu.name,
+          kind: main_menu.kind,
+          ordering: "reverse_alphabetical",
+          menu_items_attributes: {
+            "0" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "0"},
+            "1" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "1"},
+            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
+      expect(reordered).to eq(["Services", "Home", "About"])
+    end
+
+    it "uses manual reordering when ordering is default" do
+      # Submit with positions reordered: Services, Home, About
+      patch "/admin/cms/menus/#{main_menu.id}", params: {
+        menu: {
+          name: main_menu.name,
+          kind: main_menu.kind,
+          ordering: "default",
+          menu_items_attributes: {
+            "0" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "0"},
+            "1" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "1"},
+            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "2"}
+          }
+        }
+      }
+
+      expect(response).to redirect_to("/admin/cms/menus")
+
+      reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
+      expect(reordered).to eq(["Services", "Home", "About"])
+    end
+  end
+
   describe "POST /admin/cms/menus - create with reordering" do
     it "creates a menu and reorders items by position" do
       homepage = panda_cms_pages(:homepage)

--- a/spec/requests/panda/cms/admin/pages_reorder_spec.rb
+++ b/spec/requests/panda/cms/admin/pages_reorder_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin Pages - Reorder", type: :request do
+  fixtures :panda_cms_menus, :panda_cms_menu_items, :panda_cms_pages, :panda_cms_templates
+
+  let(:admin_user) { create_admin_user }
+  let(:homepage) { panda_cms_pages(:homepage) }
+  let(:about_page) { panda_cms_pages(:about_page) }
+  let(:services_page) { panda_cms_pages(:services_page) }
+
+  before do
+    post "/admin/test_sessions", params: {user_id: admin_user.id}
+  end
+
+  describe "POST /admin/cms/pages/:id/reorder" do
+    it "moves a page before a sibling" do
+      # Services(lft:6) should move before About(lft:2)
+      post "/admin/cms/pages/#{services_page.id}/reorder", params: {
+        target_id: about_page.id,
+        position: "before"
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["success"]).to be true
+
+      # Reload and check order
+      about_page.reload
+      services_page.reload
+      expect(services_page.lft).to be < about_page.lft
+    end
+
+    it "moves a page after a sibling" do
+      # About(lft:2) should move after Services(lft:6)
+      post "/admin/cms/pages/#{about_page.id}/reorder", params: {
+        target_id: services_page.id,
+        position: "after"
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+
+      about_page.reload
+      services_page.reload
+      expect(about_page.lft).to be > services_page.lft
+    end
+
+    it "rejects reordering non-siblings" do
+      team_page = panda_cms_pages(:about_team_page) # child of about, not sibling of services
+
+      post "/admin/cms/pages/#{team_page.id}/reorder", params: {
+        target_id: services_page.id,
+        position: "before"
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("Can only reorder siblings")
+    end
+
+    it "rejects invalid position values" do
+      post "/admin/cms/pages/#{about_page.id}/reorder", params: {
+        target_id: services_page.id,
+        position: "invalid"
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("Invalid position")
+    end
+
+    it "regenerates auto menus after reordering" do
+      auto_menu = panda_cms_menus(:auto_menu)
+      expect(auto_menu.start_page).to eq(homepage)
+
+      post "/admin/cms/pages/#{services_page.id}/reorder", params: {
+        target_id: about_page.id,
+        position: "before"
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Three interconnected features for menu ordering and page management:

- **Fix drag-to-reorder for static menu items**: Add `stopPropagation()` to the sortable list mousedown handler so drag events don't interfere with the collapsible item toggle (companion fix in panda-core: tastybamboo/panda-core#131)
- **Page reordering in admin pages view**: New `sortable-tree` Stimulus controller and `POST reorder` endpoint using awesome_nested_set's `move_to_left_of`/`move_to_right_of` for sibling-only drag-and-drop reordering
- **Ordering options for static menus**: Adds "A-Z", "Z-A", and "Page Order" sorting via `apply_ordering_to_static_items!`, a PostgreSQL enum migration, and a UI dropdown that hides drag handles when automatic ordering is selected

### Changes
- `sortable_list_controller.js` — `stopPropagation()` on mousedown handler
- `sortable_tree_controller.js` — New Stimulus controller for tree drag-and-drop
- `pages_controller.rb` — `reorder` action with sibling validation and auto-menu regeneration
- `menu.rb` — `apply_ordering_to_static_items!` method, extended `order_pages` for new ordering types
- `menus_controller.rb` — Permits `:ordering`, applies ordering on update
- `menu_form_controller.js` — `orderingChanged` action, drag handle visibility toggle
- Edit/new menu views — Ordering dropdown (Default/A-Z/Z-A/Page Order)
- Pages index view — Drag handles for non-root/non-archived pages
- Migration to extend `panda_cms_menu_ordering` PostgreSQL enum

## Test plan
- [ ] 743 non-system tests pass (0 failures)
- [ ] Open a static menu → change ordering to "A-Z" → save → confirm items reorder alphabetically
- [ ] Change to "Z-A" → save → confirm reverse alphabetical order
- [ ] Change to "Page Order" → save → confirm items match page tree position
- [ ] Change back to "Default" → confirm drag handles reappear and manual reorder works
- [ ] Open pages admin → drag a non-root page above/below a sibling → confirm order persists on refresh
- [ ] Verify child pages move with their parent (nested set handles this)
- [ ] Verify auto menus regenerate after page reordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)