### PR TITLE
fix: Resolve 500 error when editing posts with og_image attached

### DIFF
--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -74,7 +74,7 @@
       } %>
       <% if f.object.present? && f.object.persisted? && f.object.og_image.attached? %>
         <div class="mt-2">
-          <%= image_tag f.object.og_image.variant(:og_share), class: "max-w-xs rounded border border-gray-300" %>
+          <%= image_tag url_for(f.object.og_image.variant(:og_share)), class: "max-w-xs rounded border border-gray-300" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## Summary
- Fixes 500 error on post edit page when the post has an `og_image` attached
- The error was `ActionView::Template::Error: Can't resolve image into URL: undefined method 'to_model' for an instance of ActiveStorage::VariantWithRecord`
- Wraps the variant with `url_for()` to explicitly generate the URL before passing to `image_tag`

## Root cause
In Rails 8.x, `image_tag` cannot resolve `ActiveStorage::VariantWithRecord` objects directly via polymorphic routing. Using `url_for()` explicitly converts the variant to a URL string first, bypassing the broken `to_model` delegation.

## Test plan
- [ ] Edit a post that has an og_image attached — page should load without 500
- [ ] Edit a post without an og_image — should still work normally
- [ ] The og_image preview should render correctly in the Social Sharing panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)