### PR TITLE
fix: Use PandaCMS in migration class name to match acronym inflection

### DIFF
--- a/db/migrate/20260301233859_add_ordering_options_to_panda_cms_menus.rb
+++ b/db/migrate/20260301233859_add_ordering_options_to_panda_cms_menus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOrderingOptionsToPandaCmsMenus < ActiveRecord::Migration[8.1]
+class AddOrderingOptionsToPandaCMSMenus < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
   def up


### PR DESCRIPTION
## Summary
- Fixes `NameError: uninitialized constant AddOrderingOptionsToPandaCMSMenus` when running `db:migrate` in host apps
- The migration class was defined as `AddOrderingOptionsToPandaCmsMenus` (titlecase `Cms`) but panda-core's eager acronym inflection makes `camelize` produce `AddOrderingOptionsToPandaCMSMenus` (uppercase `CMS`)
- All other panda-cms migrations already use `PandaCMS` — this was the only inconsistent one

## Test plan
- [x] `bundle exec rails db:migrate` succeeds in neurobetter after fixing the copied migration too

🤖 Generated with [Claude Code](https://claude.com/claude-code)