### PR TITLE
fix: Add post_show_path helper to resolve 404s on date-based post URLs

### DIFF
--- a/app/controllers/panda/cms/admin/posts_controller.rb
+++ b/app/controllers/panda/cms/admin/posts_controller.rb
@@ -6,6 +6,8 @@ module Panda
   module CMS
     module Admin
       class PostsController < ::Panda::CMS::Admin::BaseController
+        helper Panda::CMS::PostsHelper
+
         before_action :set_initial_breadcrumb, only: %i[index edit new create update]
 
         # Get all posts

--- a/app/helpers/panda/cms/posts_helper.rb
+++ b/app/helpers/panda/cms/posts_helper.rb
@@ -8,6 +8,14 @@ module Panda
         CGI.unescape(post.slug)
       end
 
+      def post_show_path(post)
+        if post.year && post.month
+          post_with_date_path(post.route_params)
+        else
+          post_path(slug: post.to_param)
+        end
+      end
+
       def posts_months_menu
         Rails.cache.fetch("panda_cms_posts_months_menu", expires_in: 1.hour) do
           Panda::CMS::Post

--- a/app/helpers/panda/cms/posts_helper.rb
+++ b/app/helpers/panda/cms/posts_helper.rb
@@ -12,7 +12,7 @@ module Panda
         if post.year && post.month
           post_with_date_path(post.route_params)
         else
-          post_path(slug: post.to_param)
+          post_path(post.route_params)
         end
       end
 

--- a/app/views/panda/cms/admin/posts/edit.html.erb
+++ b/app/views/panda/cms/admin/posts/edit.html.erb
@@ -3,7 +3,7 @@
     <% if post.respond_to?(:content_versions) %>
       <% heading.with_button(action: :secondary, text: "Version History", href: admin_cms_post_versions_path(post), icon: "clock-rotate-left") %>
     <% end %>
-    <% heading.with_button(action: :view, text: "View Post", href: post_path(post.admin_param)) %>
+    <% heading.with_button(action: :view, text: "View Post", href: post_show_path(post)) %>
   <% end %>
 
   <%= render "form", post: post, url: admin_cms_post_path(post.admin_param), method: :patch %>

--- a/spec/helpers/panda/cms/posts_helper_spec.rb
+++ b/spec/helpers/panda/cms/posts_helper_spec.rb
@@ -5,6 +5,24 @@ require "rails_helper"
 RSpec.describe Panda::CMS::PostsHelper, type: :helper do
   let(:admin_user) { create_admin_user }
 
+  describe "#post_show_path" do
+    before do
+      helper.class.include Panda::CMS::Engine.routes.url_helpers
+    end
+
+    it "returns date-based path for posts with year and month in slug" do
+      post = Panda::CMS::Post.new(slug: "/2024/01/hello-world")
+      prefix = Panda::CMS.config.posts[:prefix]
+      expect(helper.post_show_path(post)).to eq("/#{prefix}/2024/01/hello-world")
+    end
+
+    it "returns simple path for posts without date segments" do
+      post = Panda::CMS::Post.new(slug: "/hello-world")
+      prefix = Panda::CMS.config.posts[:prefix]
+      expect(helper.post_show_path(post)).to eq("/#{prefix}/hello-world")
+    end
+  end
+
   describe "#display_post_path" do
     it "unescapes the post slug for display" do
       post = Panda::CMS::Post.new(slug: "/2024/01/hello-world")

--- a/spec/helpers/panda/cms/posts_helper_spec.rb
+++ b/spec/helpers/panda/cms/posts_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Panda::CMS::PostsHelper, type: :helper do
 
   describe "#post_show_path" do
     before do
-      helper.class.include Panda::CMS::Engine.routes.url_helpers
+      helper.extend Panda::CMS::Engine.routes.url_helpers
     end
 
     it "returns date-based path for posts with year and month in slug" do


### PR DESCRIPTION
## Summary
- Adds `post_show_path(post)` helper that dispatches to `post_with_date_path` or `post_path` based on whether the post slug has date segments
- Fixes admin "View Post" button which was passing `post.admin_param` (the ID) instead of the slug, generating broken URLs
- `post_path(post)` was always generating non-date URLs (`/prefix/slug`) even for posts with date-based slugs (`/prefix/YYYY/MM/slug`), causing the controller's `find_by!(slug:)` to fail with 404

## Test plan
- [x] Added helper specs for date-based and non-date post paths
- [x] All existing PostsHelper specs pass
- [ ] Verify on staging that clicking a post from the index page navigates correctly
- [ ] Verify admin "View Post" button links to the correct public URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)