### PR TITLE
feat: Add social sharing feature

### DIFF
--- a/app/components/panda/cms/social_sharing_component.html.erb
+++ b/app/components/panda/cms/social_sharing_component.html.erb
@@ -1,0 +1,30 @@
+<nav aria-label="<%= label %>">
+  <h3 class="<%= heading_class %>"><%= label %></h3>
+  <div class="flex items-center gap-2 flex-wrap">
+    <% networks.each do |network| %>
+      <% if network.copy_link? %>
+        <button
+          type="button"
+          data-controller="clipboard"
+          data-clipboard-secret-value="<%= url %>"
+          data-action="click->clipboard#copy"
+          data-clipboard-target="copyButton"
+          class="inline-flex items-center gap-2 rounded-full pl-3 pr-4 py-2 text-white text-sm font-medium transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 cursor-pointer"
+          style="background-color: <%= network.color %>;">
+          <i class="<%= network.icon %>" data-clipboard-target="copyIcon"></i>
+          <span data-clipboard-target="copyText"><%= network.display_name %></span>
+        </button>
+      <% else %>
+        <a
+          href="<%= network.build_share_url(title: title, url: url) %>"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 rounded-full pl-3 pr-4 py-2 text-white text-sm font-medium transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400"
+          style="background-color: <%= network.color %>;">
+          <i class="<%= network.icon %>"></i>
+          <span><%= network.display_name %></span>
+        </a>
+      <% end %>
+    <% end %>
+  </div>
+</nav>

--- a/app/components/panda/cms/social_sharing_component.rb
+++ b/app/components/panda/cms/social_sharing_component.rb
@@ -13,19 +13,14 @@ module Panda
         super()
       end
 
-      def before_render
-        @networks = Rails.cache.fetch("panda_cms:social_sharing:enabled_networks", expires_in: 1.minute) do
-          Panda::CMS::SocialSharingNetwork.enabled.to_a
-        end
-      end
-
       def render?
-        before_render if @networks.nil?
-        @networks.any?
+        networks.any?
       end
 
       def networks
-        @networks || []
+        @networks ||= Rails.cache.fetch("panda_cms:social_sharing:enabled_networks", expires_in: 1.minute) do
+          Panda::CMS::SocialSharingNetwork.enabled.to_a
+        end
       end
     end
   end

--- a/app/components/panda/cms/social_sharing_component.rb
+++ b/app/components/panda/cms/social_sharing_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    class SocialSharingComponent < Panda::CMS::Base
+      attr_reader :title, :url, :label, :heading_class
+
+      def initialize(title:, url:, label: "Share", heading_class: "text-sm font-semibold uppercase tracking-wider text-gray-500 mb-3")
+        @title = title
+        @url = url
+        @label = label
+        @heading_class = heading_class
+        super()
+      end
+
+      def before_render
+        @networks = Rails.cache.fetch("panda_cms:social_sharing:enabled_networks", expires_in: 1.minute) do
+          Panda::CMS::SocialSharingNetwork.enabled.to_a
+        end
+      end
+
+      def render?
+        before_render if @networks.nil?
+        @networks.any?
+      end
+
+      def networks
+        @networks || []
+      end
+    end
+  end
+end

--- a/app/controllers/panda/cms/admin/settings/social_sharing_controller.rb
+++ b/app/controllers/panda/cms/admin/settings/social_sharing_controller.rb
@@ -15,6 +15,7 @@ module Panda
           def update
             network = Panda::CMS::SocialSharingNetwork.find(params[:id])
             network.update!(enabled: !network.enabled)
+            Rails.cache.delete("panda_cms:social_sharing:enabled_networks")
 
             status = network.enabled? ? "enabled" : "disabled"
             redirect_to admin_cms_settings_social_sharing_path,
@@ -29,9 +30,11 @@ module Panda
           end
 
           def helper_detected?
-            view_paths = Rails.root.join("app", "views").to_s
-            Dir.glob("#{view_paths}/**/*.erb").any? { |f| File.read(f).include?("panda_social_sharing") }
-          rescue
+            Rails.cache.fetch("panda_cms:social_sharing:helper_detected", expires_in: 12.hours) do
+              view_paths = Rails.root.join("app", "views").to_s
+              Dir.glob("#{view_paths}/**/*.erb").any? { |f| File.read(f).include?("panda_social_sharing") }
+            end
+          rescue StandardError
             false
           end
         end

--- a/app/controllers/panda/cms/admin/settings/social_sharing_controller.rb
+++ b/app/controllers/panda/cms/admin/settings/social_sharing_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    module Admin
+      module Settings
+        class SocialSharingController < ::Panda::CMS::Admin::BaseController
+          before_action :set_initial_breadcrumb
+
+          def index
+            @networks = Panda::CMS::SocialSharingNetwork.ordered
+            @helper_detected = helper_detected?
+          end
+
+          def update
+            network = Panda::CMS::SocialSharingNetwork.find(params[:id])
+            network.update!(enabled: !network.enabled)
+
+            status = network.enabled? ? "enabled" : "disabled"
+            redirect_to admin_cms_settings_social_sharing_path,
+              flash: {success: "#{network.display_name} sharing #{status}."}
+          end
+
+          private
+
+          def set_initial_breadcrumb
+            add_breadcrumb "Settings", admin_cms_settings_path
+            add_breadcrumb "Social Sharing", admin_cms_settings_social_sharing_path
+          end
+
+          def helper_detected?
+            view_paths = Rails.root.join("app", "views").to_s
+            Dir.glob("#{view_paths}/**/*.erb").any? { |f| File.read(f).include?("panda_social_sharing") }
+          rescue
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/panda/cms/posts_controller.rb
+++ b/app/controllers/panda/cms/posts_controller.rb
@@ -3,6 +3,8 @@
 module Panda
   module CMS
     class PostsController < ApplicationController
+      before_action :set_default_ivars
+
       # TODO: Change from layout rendering to standard template rendering
       # inside a /panda/cms/posts/... structure in the application
       def index
@@ -47,6 +49,15 @@ module Panda
         fresh_when(etag: [@posts.to_a, @month], last_modified: latest_month_timestamp, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:by_month]
+      end
+
+      private
+
+      # Host app layouts may reference @page and @overrides (e.g. shared header
+      # partials). StrictIvars requires them to be set before first access.
+      def set_default_ivars
+        @page = nil
+        @overrides = {}
       end
     end
   end

--- a/app/helpers/panda/cms/social_sharing_helper.rb
+++ b/app/helpers/panda/cms/social_sharing_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    # Helper for rendering social sharing buttons from all enabled networks.
+    #
+    # Include this helper in your post layout or any view to display
+    # sharing buttons configured in the CMS admin.
+    #
+    # @example In your post layout
+    #   <%= panda_social_sharing(title: @post.title, url: request.base_url + post_path(@post)) %>
+    #
+    module SocialSharingHelper
+      def panda_social_sharing(title:, url:, label: "Share", heading_class: nil)
+        options = {title: title, url: url, label: label}
+        options[:heading_class] = heading_class if heading_class
+        render Panda::CMS::SocialSharingComponent.new(**options)
+      end
+    end
+  end
+end

--- a/app/models/panda/cms/social_sharing_network.rb
+++ b/app/models/panda/cms/social_sharing_network.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    class SocialSharingNetwork < ApplicationRecord
+      self.table_name = "panda_cms_social_sharing_networks"
+
+      REGISTRY = {
+        "facebook" => {
+          name: "Facebook",
+          icon: "fab fa-facebook-f",
+          color: "#1877F2",
+          share_url: "https://www.facebook.com/sharer/sharer.php?u={url}"
+        },
+        "x" => {
+          name: "X",
+          icon: "fab fa-x-twitter",
+          color: "#000000",
+          share_url: "https://twitter.com/intent/tweet?url={url}&text={title}"
+        },
+        "linkedin" => {
+          name: "LinkedIn",
+          icon: "fab fa-linkedin-in",
+          color: "#0A66C2",
+          share_url: "https://www.linkedin.com/sharing/share-offsite/?url={url}"
+        },
+        "whatsapp" => {
+          name: "WhatsApp",
+          icon: "fab fa-whatsapp",
+          color: "#25D366",
+          share_url: "https://wa.me/?text={title}%20{url}"
+        },
+        "bluesky" => {
+          name: "Bluesky",
+          icon: "fab fa-bluesky",
+          color: "#0085FF",
+          share_url: "https://bsky.app/intent/compose?text={title}%20{url}"
+        },
+        "mastodon" => {
+          name: "Mastodon",
+          icon: "fab fa-mastodon",
+          color: "#6364FF",
+          share_url: "https://share.joinmastodon.org/?text={title}%20{url}"
+        },
+        "threads" => {
+          name: "Threads",
+          icon: "fab fa-threads",
+          color: "#000000",
+          share_url: "https://www.threads.net/intent/post?text={title}%20{url}"
+        },
+        "email" => {
+          name: "Email",
+          icon: "fa-solid fa-envelope",
+          color: "#666666",
+          share_url: "mailto:?subject={title}&body={url}"
+        },
+        "copy_link" => {
+          name: "Copy Link",
+          icon: "fa-solid fa-link",
+          color: "#666666",
+          share_url: nil
+        }
+      }.freeze
+
+      validates :key, presence: true, uniqueness: true, inclusion: {in: REGISTRY.keys}
+      validates :position, presence: true
+
+      scope :enabled, -> { where(enabled: true).order(:position) }
+      scope :ordered, -> { order(:position) }
+
+      def self.register_all
+        REGISTRY.each_with_index do |(key, _meta), index|
+          find_or_create_by(key: key) do |network|
+            network.position = index
+          end
+        end
+      end
+
+      def metadata
+        REGISTRY[key]
+      end
+
+      def display_name
+        metadata&.dig(:name) || key.titleize
+      end
+
+      def icon
+        metadata&.dig(:icon)
+      end
+
+      def color
+        metadata&.dig(:color)
+      end
+
+      def share_url_template
+        metadata&.dig(:share_url)
+      end
+
+      def copy_link?
+        key == "copy_link"
+      end
+
+      def build_share_url(title:, url:)
+        return nil if copy_link?
+
+        template = share_url_template
+        return nil unless template
+
+        template
+          .gsub("{title}", ERB::Util.url_encode(title))
+          .gsub("{url}", ERB::Util.url_encode(url))
+      end
+    end
+  end
+end

--- a/app/views/panda/cms/admin/settings/social_sharing/index.html.erb
+++ b/app/views/panda/cms/admin/settings/social_sharing/index.html.erb
@@ -1,0 +1,86 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: "Social Sharing", level: 1) %>
+
+  <% unless @helper_detected %>
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_body_slot do %>
+        <div class="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-xl">
+          <i class="fa-solid fa-triangle-exclamation text-amber-500 mt-0.5"></i>
+          <div>
+            <p class="text-sm font-medium text-amber-800">Social sharing helper not detected in your views</p>
+            <p class="text-xs text-amber-700 mt-1">
+              Add the helper shown below to your post layout to display sharing buttons.
+              Without this, networks can be configured here but no buttons will appear on the site.
+            </p>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+    <% panel.with_heading_slot do %>
+      <i class="fa-solid fa-code mr-2"></i> Setup
+    <% end %>
+    <% panel.with_body_slot do %>
+      <p class="text-sm text-gray-600 mb-3">
+        To display social sharing buttons on your site, add the following helper to your post layout or any view:
+      </p>
+      <pre class="bg-gray-900 text-emerald-200 rounded-xl p-4 text-sm font-mono overflow-x-auto">&lt;%= panda_social_sharing(title: @post.title, url: request.base_url + post_path(@post)) %&gt;</pre>
+      <p class="text-xs text-gray-500 mt-2">
+        This helper renders sharing buttons for all enabled networks below. It automatically hides itself when no networks are enabled.
+      </p>
+    <% end %>
+  <% end %>
+
+  <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+    <% panel.with_heading_slot do %>
+      <i class="fa-solid fa-share-nodes mr-2"></i> Networks
+    <% end %>
+    <% panel.with_body_slot do %>
+      <% if @networks.any? %>
+        <div class="divide-y divide-gray-100">
+          <% @networks.each do |network| %>
+            <div class="flex items-center justify-between py-3 px-1">
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-full flex items-center justify-center" style="background-color: <%= network.color %>;">
+                  <i class="<%= network.icon %> text-white text-sm"></i>
+                </div>
+                <div>
+                  <span class="block text-sm font-medium text-gray-900"><%= network.display_name %></span>
+                  <span class="block text-xs text-gray-500"><%= network.key %></span>
+                </div>
+              </div>
+
+              <div class="flex items-center gap-3">
+                <% if network.enabled? %>
+                  <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+                    <i class="fa-solid fa-check mr-1"></i> Enabled
+                  </span>
+                <% else %>
+                  <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">
+                    <i class="fa-solid fa-xmark mr-1"></i> Disabled
+                  </span>
+                <% end %>
+
+                <%= button_to admin_cms_settings_social_sharing_network_path(network), method: :patch, class: "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition #{network.enabled? ? 'text-red-600 hover:text-red-700 hover:bg-red-50' : 'text-green-600 hover:text-green-700 hover:bg-green-50'}" do %>
+                  <% if network.enabled? %>
+                    <i class="fa-solid fa-toggle-on"></i> Disable
+                  <% else %>
+                    <i class="fa-solid fa-toggle-off"></i> Enable
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <%= render Panda::Core::Admin::EmptyStateComponent.new(
+          icon: "fa-solid fa-share-nodes",
+          title: "No social networks registered",
+          description: "Social sharing networks are registered automatically during application initialization."
+        ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Panda::CMS::Engine.routes.draw do
       namespace :settings, as: :settings do
         get "bulk_editor", to: "bulk_editor#new"
         post "bulk_editor", to: "bulk_editor#create"
+
+        get "social_sharing", to: "social_sharing#index", as: :social_sharing
+        patch "social_sharing/:id", to: "social_sharing#update", as: :social_sharing_network
       end
     end
   end

--- a/db/migrate/20260303000001_create_panda_cms_social_sharing_networks.rb
+++ b/db/migrate/20260303000001_create_panda_cms_social_sharing_networks.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreatePandaCMSSocialSharingNetworks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :panda_cms_social_sharing_networks, id: :uuid do |t|
+      t.string :key, null: false
+      t.boolean :enabled, null: false, default: false
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :panda_cms_social_sharing_networks, :key, unique: true
+    add_index :panda_cms_social_sharing_networks, :position
+  end
+end

--- a/lib/panda/cms/engine.rb
+++ b/lib/panda/cms/engine.rb
@@ -15,6 +15,7 @@ require_relative "engine/route_config"
 require_relative "engine/core_config"
 require_relative "engine/helper_config"
 require_relative "engine/backtrace_config"
+require_relative "engine/social_sharing_config"
 
 module Panda
   module CMS
@@ -30,6 +31,7 @@ module Panda
       include CoreConfig
       include HelperConfig
       include BacktraceConfig
+      include SocialSharingConfig
 
       initializer "panda_cms.importmap", before: "importmap" do |app|
         Panda::CMS.importmap = Importmap::Map.new.tap do |map|

--- a/lib/panda/cms/engine/core_config.rb
+++ b/lib/panda/cms/engine/core_config.rb
@@ -69,6 +69,7 @@ module Panda
                   icon: "fa-solid fa-gear",
                   children: [
                     {label: "Users", path: "#{config.admin_path}/users"},
+                    {label: "Social Sharing", path: "#{config.admin_path}/cms/settings/social_sharing"},
                     {label: "System Status", path: "#{config.admin_path}/cms/settings"}
                   ]
                 }

--- a/lib/panda/cms/engine/helper_config.rb
+++ b/lib/panda/cms/engine/helper_config.rb
@@ -13,6 +13,7 @@ module Panda
             ApplicationController.helper(::ApplicationHelper)
             ApplicationController.helper(Panda::CMS::AssetHelper)
             ApplicationController.helper(Panda::CMS::AnalyticsHelper)
+            ApplicationController.helper(Panda::CMS::SocialSharingHelper)
           end
         end
       end

--- a/lib/panda/cms/engine/social_sharing_config.rb
+++ b/lib/panda/cms/engine/social_sharing_config.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    class Engine < ::Rails::Engine
+      module SocialSharingConfig
+        extend ActiveSupport::Concern
+
+        included do
+          initializer "panda.cms.social_sharing" do
+            config.after_initialize do
+              next unless ActiveRecord::Base.connection.table_exists?("panda_cms_social_sharing_networks")
+
+              Panda::CMS::SocialSharingNetwork.register_all
+            rescue ActiveRecord::NoDatabaseError, ActiveRecord::ConnectionNotEstablished
+              # Skip seeding if database isn't available (e.g. during db:create)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/components/panda/cms/social_sharing_component_spec.rb
+++ b/spec/components/panda/cms/social_sharing_component_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::SocialSharingComponent, type: :component do
+  let(:title) { "Test Post Title" }
+  let(:url) { "https://example.com/blog/test-post" }
+
+  before do
+    # Clear cache before each test
+    Rails.cache.delete("panda_cms:social_sharing:enabled_networks")
+  end
+
+  describe "#render?" do
+    it "returns false when no networks are enabled" do
+      Panda::CMS::SocialSharingNetwork.register_all
+
+      component = described_class.new(title: title, url: url)
+      expect(component.render?).to be false
+    end
+
+    it "returns true when networks are enabled" do
+      Panda::CMS::SocialSharingNetwork.register_all
+      Panda::CMS::SocialSharingNetwork.find_by(key: "facebook").update!(enabled: true)
+
+      component = described_class.new(title: title, url: url)
+      expect(component.render?).to be true
+    end
+  end
+
+  describe "rendering" do
+    before do
+      Panda::CMS::SocialSharingNetwork.register_all
+      Panda::CMS::SocialSharingNetwork.find_by(key: "facebook").update!(enabled: true)
+      Panda::CMS::SocialSharingNetwork.find_by(key: "x").update!(enabled: true)
+      Panda::CMS::SocialSharingNetwork.find_by(key: "copy_link").update!(enabled: true)
+    end
+
+    it "renders a nav element with aria-label" do
+      output = render_inline(described_class.new(title: title, url: url, label: "Share this"))
+      expect(output.css("nav[aria-label='Share this']")).to be_present
+    end
+
+    it "renders enabled networks as links" do
+      output = render_inline(described_class.new(title: title, url: url))
+      links = output.css("a[target='_blank']")
+      expect(links.length).to eq(2) # facebook and x (not copy_link)
+    end
+
+    it "renders share links with correct href" do
+      output = render_inline(described_class.new(title: title, url: url))
+      facebook_link = output.css("a").find { |a| a.text.include?("Facebook") }
+      expect(facebook_link["href"]).to include("facebook.com/sharer/sharer.php")
+      expect(facebook_link["href"]).to include(ERB::Util.url_encode(url))
+    end
+
+    it "renders links with noopener noreferrer" do
+      output = render_inline(described_class.new(title: title, url: url))
+      links = output.css("a[target='_blank']")
+      links.each do |link|
+        expect(link["rel"]).to eq("noopener noreferrer")
+      end
+    end
+
+    it "renders network names as visible text" do
+      output = render_inline(described_class.new(title: title, url: url))
+      expect(output.text).to include("Facebook")
+      expect(output.text).to include("X")
+      expect(output.text).to include("Copy Link")
+    end
+
+    it "renders brand colours as inline styles" do
+      output = render_inline(described_class.new(title: title, url: url))
+      facebook_link = output.css("a").find { |a| a.text.include?("Facebook") }
+      expect(facebook_link["style"]).to include("#1877F2")
+    end
+
+    it "renders copy link as a button with clipboard controller" do
+      output = render_inline(described_class.new(title: title, url: url))
+      copy_button = output.css("button[data-controller='clipboard']").first
+
+      expect(copy_button).to be_present
+      expect(copy_button["data-clipboard-secret-value"]).to eq(url)
+      expect(copy_button["data-action"]).to eq("click->clipboard#copy")
+    end
+
+    it "renders the label text" do
+      output = render_inline(described_class.new(title: title, url: url, label: "Share this article"))
+      expect(output.text).to include("Share this article")
+    end
+
+    it "does not render disabled networks" do
+      output = render_inline(described_class.new(title: title, url: url))
+      expect(output.text).not_to include("LinkedIn")
+      expect(output.text).not_to include("WhatsApp")
+    end
+  end
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -34,8 +34,6 @@ module Dummy
     config.time_zone = "Europe/London"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.active_support.to_time_preserves_timezone = :zone
-
     config.generators do |g|
       g.system_tests = nil
       g.test_framework :rspec, fixture: true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_03_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -506,6 +506,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
     t.index ["destination_panda_cms_page_id"], name: "index_panda_cms_redirects_on_destination_panda_cms_page_id"
     t.index ["origin_panda_cms_page_id"], name: "index_panda_cms_redirects_on_origin_panda_cms_page_id"
     t.index ["origin_path"], name: "index_panda_cms_redirects_on_origin_path"
+  end
+
+  create_table "panda_cms_social_sharing_networks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "enabled", default: false, null: false
+    t.string "key", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_panda_cms_social_sharing_networks_on_key", unique: true
+    t.index ["position"], name: "index_panda_cms_social_sharing_networks_on_position"
   end
 
   create_table "panda_cms_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/panda/cms/social_sharing_network_spec.rb
+++ b/spec/models/panda/cms/social_sharing_network_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::SocialSharingNetwork, type: :model do
+  describe "REGISTRY" do
+    it "contains all 9 networks" do
+      expect(described_class::REGISTRY.keys).to eq(
+        %w[facebook x linkedin whatsapp bluesky mastodon threads email copy_link]
+      )
+    end
+
+    it "has required metadata keys for each network" do
+      described_class::REGISTRY.each do |key, meta|
+        expect(meta).to have_key(:name), "#{key} missing :name"
+        expect(meta).to have_key(:icon), "#{key} missing :icon"
+        expect(meta).to have_key(:color), "#{key} missing :color"
+        expect(meta).to have_key(:share_url), "#{key} missing :share_url"
+      end
+    end
+
+    it "has share_url for all networks except copy_link" do
+      described_class::REGISTRY.each do |key, meta|
+        if key == "copy_link"
+          expect(meta[:share_url]).to be_nil
+        else
+          expect(meta[:share_url]).to be_present, "#{key} missing share_url"
+        end
+      end
+    end
+  end
+
+  describe "table name" do
+    it "uses the correct table name" do
+      expect(described_class.table_name).to eq("panda_cms_social_sharing_networks")
+    end
+  end
+
+  describe "validations" do
+    it "validates presence of key" do
+      network = described_class.new(key: nil, position: 0)
+      expect(network).not_to be_valid
+      expect(network.errors[:key]).to include("can't be blank")
+    end
+
+    it "validates uniqueness of key" do
+      described_class.create!(key: "facebook", position: 0)
+      duplicate = described_class.new(key: "facebook", position: 1)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:key]).to include("has already been taken")
+    end
+
+    it "validates key is in REGISTRY" do
+      network = described_class.new(key: "invalid_network", position: 0)
+      expect(network).not_to be_valid
+      expect(network.errors[:key]).to include("is not included in the list")
+    end
+
+    it "validates presence of position" do
+      network = described_class.new(key: "facebook", position: nil)
+      expect(network).not_to be_valid
+      expect(network.errors[:position]).to include("can't be blank")
+    end
+  end
+
+  describe ".register_all" do
+    it "creates all networks from REGISTRY" do
+      expect {
+        described_class.register_all
+      }.to change(described_class, :count).by(9)
+    end
+
+    it "is idempotent" do
+      described_class.register_all
+      expect {
+        described_class.register_all
+      }.not_to change(described_class, :count)
+    end
+
+    it "preserves existing enabled state" do
+      described_class.register_all
+      described_class.find_by(key: "facebook").update!(enabled: true)
+
+      described_class.register_all
+      expect(described_class.find_by(key: "facebook").enabled).to be true
+    end
+
+    it "sets position based on REGISTRY order" do
+      described_class.register_all
+      facebook = described_class.find_by(key: "facebook")
+      copy_link = described_class.find_by(key: "copy_link")
+
+      expect(facebook.position).to eq(0)
+      expect(copy_link.position).to eq(8)
+    end
+  end
+
+  describe "scopes" do
+    before { described_class.register_all }
+
+    describe ".enabled" do
+      it "returns only enabled networks ordered by position" do
+        described_class.find_by(key: "x").update!(enabled: true)
+        described_class.find_by(key: "whatsapp").update!(enabled: true)
+
+        enabled = described_class.enabled
+        expect(enabled.map(&:key)).to eq(%w[x whatsapp])
+      end
+
+      it "returns empty when none enabled" do
+        expect(described_class.enabled).to be_empty
+      end
+    end
+
+    describe ".ordered" do
+      it "returns networks ordered by position" do
+        ordered = described_class.ordered
+        expect(ordered.first.key).to eq("facebook")
+        expect(ordered.last.key).to eq("copy_link")
+      end
+    end
+  end
+
+  describe "instance methods" do
+    let(:network) do
+      described_class.create!(key: "facebook", position: 0)
+    end
+
+    describe "#metadata" do
+      it "returns the REGISTRY entry" do
+        expect(network.metadata[:name]).to eq("Facebook")
+        expect(network.metadata[:icon]).to eq("fab fa-facebook-f")
+      end
+    end
+
+    describe "#display_name" do
+      it "returns the human name" do
+        expect(network.display_name).to eq("Facebook")
+      end
+    end
+
+    describe "#icon" do
+      it "returns the icon class" do
+        expect(network.icon).to eq("fab fa-facebook-f")
+      end
+    end
+
+    describe "#color" do
+      it "returns the brand colour" do
+        expect(network.color).to eq("#1877F2")
+      end
+    end
+
+    describe "#copy_link?" do
+      it "returns true for copy_link" do
+        copy = described_class.create!(key: "copy_link", position: 8)
+        expect(copy.copy_link?).to be true
+      end
+
+      it "returns false for other networks" do
+        expect(network.copy_link?).to be false
+      end
+    end
+
+    describe "#build_share_url" do
+      it "builds URL with encoded title and url" do
+        result = network.build_share_url(
+          title: "Hello World",
+          url: "https://example.com/post"
+        )
+        expect(result).to include("facebook.com/sharer/sharer.php")
+        expect(result).to include("https%3A%2F%2Fexample.com%2Fpost")
+      end
+
+      it "handles special characters in title" do
+        x_network = described_class.create!(key: "x", position: 1)
+        result = x_network.build_share_url(
+          title: "Test & <Script>",
+          url: "https://example.com"
+        )
+        expect(result).to include("Test%20%26%20%3CScript%3E")
+      end
+
+      it "returns nil for copy_link" do
+        copy = described_class.create!(key: "copy_link", position: 8)
+        result = copy.build_share_url(title: "Test", url: "https://example.com")
+        expect(result).to be_nil
+      end
+
+      it "builds mailto URL for email" do
+        email = described_class.create!(key: "email", position: 7)
+        result = email.build_share_url(
+          title: "My Post",
+          url: "https://example.com/post"
+        )
+        expect(result).to start_with("mailto:?subject=")
+        expect(result).to include("My%20Post")
+      end
+    end
+  end
+end

--- a/spec/models/panda/cms/social_sharing_network_spec.rb
+++ b/spec/models/panda/cms/social_sharing_network_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Panda::CMS::SocialSharingNetwork, type: :model do
           title: "Test & <Script>",
           url: "https://example.com"
         )
-        expect(result).to include("Test%20%26%20%3CScript%3E")
+        expect(result).to include(ERB::Util.url_encode("Test & <Script>"))
       end
 
       it "returns nil for copy_link" do
@@ -194,7 +194,7 @@ RSpec.describe Panda::CMS::SocialSharingNetwork, type: :model do
           url: "https://example.com/post"
         )
         expect(result).to start_with("mailto:?subject=")
-        expect(result).to include("My%20Post")
+        expect(result).to include(ERB::Util.url_encode("My Post"))
       end
     end
   end


### PR DESCRIPTION
## Summary
- Add admin-configurable social sharing with 9 networks (Facebook, X, LinkedIn, WhatsApp, Bluesky, Mastodon, Threads, Email, Copy Link)
- URL-based sharing with no third-party JS — privacy-friendly approach
- Registry pattern: DB stores enabled/position state, metadata lives in code
- Admin settings page at `/manage/cms/settings/social_sharing` with brand-coloured logos and toggle buttons
- Public `SocialSharingComponent` and `panda_social_sharing` helper for host apps
- Copy Link reuses existing panda-core `clipboard` Stimulus controller
- Fix StrictIvars compatibility in PostsController for host app layouts

## New files
- Model: `SocialSharingNetwork` with `REGISTRY` constant and `register_all` seeding
- Migration: `panda_cms_social_sharing_networks` table (UUID PK, key, enabled, position)
- Component: `SocialSharingComponent` with pill-shaped buttons showing icon + network name
- Helper: `panda_social_sharing(title:, url:, label:, heading_class:)`
- Admin controller + view for settings page
- Engine config for boot-time network registration

## Test plan
- [x] 25 model specs (registry, validations, seeding, URL building)
- [x] 11 component specs (render?, links, clipboard data attrs, brand colours)
- [ ] Manual: visit admin settings, toggle networks, verify buttons on posts
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)