### PR TITLE
feat: Add post categories with admin CRUD and public filtering

### DIFF
--- a/app/controllers/panda/cms/admin/post_categories_controller.rb
+++ b/app/controllers/panda/cms/admin/post_categories_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    module Admin
+      class PostCategoriesController < ::Panda::CMS::Admin::BaseController
+        before_action :set_initial_breadcrumb
+        before_action :set_post_category, only: %i[edit update destroy]
+
+        def index
+          post_categories = Panda::CMS::PostCategory.ordered
+          render :index, locals: {post_categories: post_categories}
+        end
+
+        def new
+          post_category = Panda::CMS::PostCategory.new
+          add_breadcrumb "New Category", new_admin_cms_post_category_path
+          render :new, locals: {post_category: post_category}
+        end
+
+        def create
+          post_category = Panda::CMS::PostCategory.new(post_category_params)
+
+          if post_category.save
+            redirect_to edit_admin_cms_post_category_path(post_category), notice: "Category was successfully created."
+          else
+            add_breadcrumb "New Category", new_admin_cms_post_category_path
+            render :new, locals: {post_category: post_category}, status: :unprocessable_entity
+          end
+        end
+
+        def edit
+          add_breadcrumb @post_category.name, edit_admin_cms_post_category_path(@post_category)
+          render :edit, locals: {post_category: @post_category}
+        end
+
+        def update
+          if @post_category.update(post_category_params)
+            redirect_to edit_admin_cms_post_category_path(@post_category), notice: "Category was successfully updated.", status: :see_other
+          else
+            add_breadcrumb @post_category.name, edit_admin_cms_post_category_path(@post_category)
+            render :edit, locals: {post_category: @post_category}, status: :unprocessable_entity
+          end
+        end
+
+        def destroy
+          if !@post_category.deletable?
+            redirect_to admin_cms_post_categories_path, alert: "The default category cannot be deleted.", status: :see_other
+          elsif @post_category.posts.any?
+            redirect_to admin_cms_post_categories_path, alert: "Cannot delete a category that has posts. Reassign them first.", status: :see_other
+          else
+            @post_category.destroy
+            redirect_to admin_cms_post_categories_path, notice: "Category was successfully deleted.", status: :see_other
+          end
+        end
+
+        private
+
+        def set_post_category
+          @post_category = Panda::CMS::PostCategory.find(params[:id])
+        end
+
+        def set_initial_breadcrumb
+          add_breadcrumb "Post Categories", admin_cms_post_categories_path
+        end
+
+        def post_category_params
+          params.require(:post_category).permit(:name, :slug, :description)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/panda/cms/admin/post_categories_controller.rb
+++ b/app/controllers/panda/cms/admin/post_categories_controller.rb
@@ -8,7 +8,11 @@ module Panda
         before_action :set_post_category, only: %i[edit update destroy]
 
         def index
-          post_categories = Panda::CMS::PostCategory.ordered
+          post_categories = Panda::CMS::PostCategory
+            .left_joins(:posts)
+            .select("panda_cms_post_categories.*, COUNT(panda_cms_posts.id) AS posts_count")
+            .group("panda_cms_post_categories.id")
+            .ordered
           render :index, locals: {post_categories: post_categories}
         end
 

--- a/app/controllers/panda/cms/admin/posts_controller.rb
+++ b/app/controllers/panda/cms/admin/posts_controller.rb
@@ -9,12 +9,13 @@ module Panda
         helper Panda::CMS::PostsHelper
 
         before_action :set_initial_breadcrumb, only: %i[index edit new create update]
+        before_action :handle_new_category, only: %i[create update]
 
         # Get all posts
         # @type GET
         # @return ActiveRecord::Collection A list of all posts
         def index
-          posts = Panda::CMS::Post.with_author.ordered
+          posts = Panda::CMS::Post.with_author.with_category.ordered
           render :index, locals: {posts: posts}
         end
 
@@ -101,7 +102,8 @@ module Panda
 
           post ||= Panda::CMS::Post.new(
             status: "published",
-            published_at: Time.zone.now
+            published_at: Time.zone.now,
+            post_category: Panda::CMS::PostCategory.find_by(slug: "general")
           )
 
           {
@@ -121,10 +123,19 @@ module Panda
             :status,
             :published_at,
             :author_id,
+            :post_category_id,
             :content,
             :seo_title, :seo_description, :seo_keywords, :seo_index_mode, :canonical_url,
             :og_title, :og_description, :og_type, :og_image
           )
+        end
+
+        def handle_new_category
+          new_name = params.dig(:post, :new_category_name)
+          return if new_name.blank?
+
+          category = Panda::CMS::PostCategory.find_or_create_by!(name: new_name.strip)
+          params[:post][:post_category_id] = category.id
         end
 
         def parse_content(content)

--- a/app/controllers/panda/cms/admin/posts_controller.rb
+++ b/app/controllers/panda/cms/admin/posts_controller.rb
@@ -103,7 +103,7 @@ module Panda
           post ||= Panda::CMS::Post.new(
             status: "published",
             published_at: Time.zone.now,
-            post_category: Panda::CMS::PostCategory.find_by(slug: "general")
+            post_category: Panda::CMS::PostCategory.find_or_create_by!(slug: "general") { |c| c.name = "General" }
           )
 
           {

--- a/app/controllers/panda/cms/posts_controller.rb
+++ b/app/controllers/panda/cms/posts_controller.rb
@@ -6,7 +6,8 @@ module Panda
       # TODO: Change from layout rendering to standard template rendering
       # inside a /panda/cms/posts/... structure in the application
       def index
-        @posts = Panda::CMS::Post.where(status: :published).includes(:author).order(published_at: :desc)
+        @posts = Panda::CMS::Post.where(status: :published).includes(:author, :post_category).order(published_at: :desc)
+        @post_categories = Panda::CMS::PostCategory.ordered
 
         # HTTP caching: Use the most recent post's updated_at for conditional requests
         # Returns 304 Not Modified if no posts have changed since client's last request
@@ -31,6 +32,20 @@ module Panda
         fresh_when(@post, last_modified: @post.updated_at, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:show]
+      end
+
+      def by_category
+        @post_category = Panda::CMS::PostCategory.find_by!(slug: params[:category_slug])
+        @posts = Panda::CMS::Post
+          .where(status: :published)
+          .where(post_category: @post_category)
+          .includes(:author, :post_category)
+          .ordered
+
+        latest_timestamp = @posts.maximum(:updated_at) || Time.current
+        fresh_when(etag: [@posts.to_a, @post_category], last_modified: latest_timestamp, public: true)
+
+        render inline: "", layout: Panda::CMS.config.posts[:layouts][:index]
       end
 
       def by_month

--- a/app/controllers/panda/cms/posts_controller.rb
+++ b/app/controllers/panda/cms/posts_controller.rb
@@ -12,7 +12,7 @@ module Panda
         # HTTP caching: Use the most recent post's updated_at for conditional requests
         # Returns 304 Not Modified if no posts have changed since client's last request
         latest_post_timestamp = @posts.maximum(:updated_at) || Time.current
-        fresh_when(etag: [@posts.to_a, latest_post_timestamp], last_modified: latest_post_timestamp, public: true)
+        fresh_when(etag: [@posts.count, latest_post_timestamp], last_modified: latest_post_timestamp, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:index]
       end
@@ -42,8 +42,8 @@ module Panda
           .includes(:author, :post_category)
           .ordered
 
-        latest_timestamp = @posts.maximum(:updated_at) || Time.current
-        fresh_when(etag: [@posts.to_a, @post_category], last_modified: latest_timestamp, public: true)
+        latest_timestamp = @posts.maximum(:updated_at) || @post_category.updated_at
+        fresh_when(etag: [@post_category.cache_key_with_version, @posts.count, latest_timestamp], last_modified: latest_timestamp, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:index]
       end
@@ -59,7 +59,7 @@ module Panda
         # HTTP caching: Use the most recent post in this month for conditional requests
         # Returns 304 Not Modified if no posts in this month have changed
         latest_month_timestamp = @posts.maximum(:updated_at) || @month
-        fresh_when(etag: [@posts.to_a, @month], last_modified: latest_month_timestamp, public: true)
+        fresh_when(etag: [@month, @posts.count, latest_month_timestamp], last_modified: latest_month_timestamp, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:by_month]
       end

--- a/app/helpers/panda/cms/posts_helper.rb
+++ b/app/helpers/panda/cms/posts_helper.rb
@@ -16,6 +16,10 @@ module Panda
         end
       end
 
+      def post_category_url(category)
+        "#{Panda::CMS.config.posts[:prefix]}/category/#{category.slug}"
+      end
+
       def posts_months_menu
         Rails.cache.fetch("panda_cms_posts_months_menu", expires_in: 1.hour) do
           Panda::CMS::Post

--- a/app/javascript/panda/cms/controllers/category_select_controller.js
+++ b/app/javascript/panda/cms/controllers/category_select_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["select", "toggleButton", "newCategoryFields", "newCategoryInput"]
+
+  toggleNewCategory() {
+    const isShowingNew = !this.newCategoryFieldsTarget.classList.contains("hidden")
+
+    if (isShowingNew) {
+      // Switch back to existing category select
+      this.newCategoryFieldsTarget.classList.add("hidden")
+      this.selectTarget.disabled = false
+      this.newCategoryInputTarget.value = ""
+      this.toggleButtonTarget.textContent = "+ Add new category"
+    } else {
+      // Switch to new category input
+      this.newCategoryFieldsTarget.classList.remove("hidden")
+      this.selectTarget.disabled = true
+      this.newCategoryInputTarget.focus()
+      this.toggleButtonTarget.textContent = "Choose existing category"
+    }
+  }
+}

--- a/app/javascript/panda/cms/controllers/index.js
+++ b/app/javascript/panda/cms/controllers/index.js
@@ -35,7 +35,8 @@ const cmsControllers = [
   ["datetime", "/panda/cms/controllers/datetime_controller.js"],
   ["editor-form", "/panda/cms/controllers/editor_form_controller.js"],
   ["editor-iframe", "/panda/cms/controllers/editor_iframe_controller.js"],
-  ["signature-pad", "/panda/cms/controllers/signature_pad_controller.js"]
+  ["signature-pad", "/panda/cms/controllers/signature_pad_controller.js"],
+  ["category-select", "/panda/cms/controllers/category_select_controller.js"]
 ]
 
 // Load all controllers with error handling

--- a/app/models/panda/cms/post.rb
+++ b/app/models/panda/cms/post.rb
@@ -14,6 +14,7 @@ module Panda
 
       belongs_to :user, class_name: "Panda::Core::User"
       belongs_to :author, class_name: "Panda::Core::User", optional: true
+      belongs_to :post_category, class_name: "Panda::CMS::PostCategory"
       has_many :block_contents, as: :blockable, dependent: :destroy
       has_many :blocks, through: :block_contents
 
@@ -37,6 +38,8 @@ module Panda
       end
       scope :with_user, -> { includes(:user) }
       scope :with_author, -> { includes(:author) }
+      scope :with_category, -> { includes(:post_category) }
+      scope :by_category, ->(category) { where(post_category: category) }
 
       enum :status, {
         published: "published",

--- a/app/models/panda/cms/post_category.rb
+++ b/app/models/panda/cms/post_category.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    class PostCategory < ApplicationRecord
+      self.table_name = "panda_cms_post_categories"
+
+      has_many :posts, class_name: "Panda::CMS::Post", foreign_key: :post_category_id, dependent: :restrict_with_error
+
+      validates :name, presence: true, uniqueness: true
+      validates :slug, presence: true, uniqueness: true,
+        format: {with: /\A[a-z0-9-]+\z/, message: "must contain only lowercase letters, numbers, and hyphens"}
+
+      before_validation :generate_slug
+
+      scope :ordered, -> { order(:name) }
+
+      def deletable?
+        slug != "general"
+      end
+
+      private
+
+      def generate_slug
+        return if name.blank?
+
+        self.slug = name.parameterize if slug.blank?
+      end
+    end
+  end
+end

--- a/app/views/panda/cms/admin/post_categories/edit.html.erb
+++ b/app/views/panda/cms/admin/post_categories/edit.html.erb
@@ -1,0 +1,31 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: post_category.name, level: 1) do |heading| %>
+    <% if post_category.deletable? %>
+      <% heading.with_button(
+        action: :delete,
+        text: "Delete",
+        href: admin_cms_post_category_path(post_category),
+        data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this category?" }
+      ) %>
+    <% end %>
+  <% end %>
+
+  <%= panda_form_with model: post_category, url: admin_cms_post_category_path(post_category), method: :patch do |f| %>
+    <%= render Panda::Core::Admin::FormErrorComponent.new(model: post_category) %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Category Settings" } %>
+
+      <div class="space-y-4" data-controller="slug">
+        <%= f.text_field :name,
+            data: { "slug-target": "input_text" },
+            "data-action": "focusout->slug#generatePath" %>
+        <%= f.text_field :slug,
+            data: { "slug-target": "output_text" } %>
+        <%= f.text_area :description, rows: 3 %>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::FormFooterComponent.new(submit_text: "Save Category") %>
+  <% end %>
+<% end %>

--- a/app/views/panda/cms/admin/post_categories/index.html.erb
+++ b/app/views/panda/cms/admin/post_categories/index.html.erb
@@ -1,0 +1,13 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: "Post Categories", level: 1) do |heading| %>
+    <% heading.with_button(action: :add, text: "Add Category", href: new_admin_cms_post_category_path) %>
+  <% end %>
+
+  <%= render Panda::Core::Admin::TableComponent.new(term: "category", rows: post_categories, icon: "fa-solid fa-folder") do |table| %>
+    <% table.column("Name") do |category| %>
+      <%= link_to category.name, edit_admin_cms_post_category_path(category), class: "block h-full w-full" %>
+    <% end %>
+    <% table.column("Slug") { |category| category.slug } %>
+    <% table.column("Posts", width: "80px") { |category| category.posts.size } %>
+  <% end %>
+<% end %>

--- a/app/views/panda/cms/admin/post_categories/index.html.erb
+++ b/app/views/panda/cms/admin/post_categories/index.html.erb
@@ -8,6 +8,6 @@
       <%= link_to category.name, edit_admin_cms_post_category_path(category), class: "block h-full w-full" %>
     <% end %>
     <% table.column("Slug") { |category| category.slug } %>
-    <% table.column("Posts", width: "80px") { |category| category.posts.size } %>
+    <% table.column("Posts", width: "80px") { |category| category.posts_count } %>
   <% end %>
 <% end %>

--- a/app/views/panda/cms/admin/post_categories/new.html.erb
+++ b/app/views/panda/cms/admin/post_categories/new.html.erb
@@ -1,0 +1,22 @@
+<%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
+  <% component.with_heading_slot(text: "Add Category", level: 1) %>
+
+  <%= panda_form_with model: post_category, url: admin_cms_post_categories_path, method: :post do |f| %>
+    <%= render Panda::Core::Admin::FormErrorComponent.new(model: post_category) %>
+
+    <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
+      <% panel.with_heading_slot { "Category Settings" } %>
+
+      <div class="space-y-4" data-controller="slug">
+        <%= f.text_field :name,
+            data: { "slug-target": "input_text" },
+            "data-action": "focusout->slug#generatePath" %>
+        <%= f.text_field :slug,
+            data: { "slug-target": "output_text" } %>
+        <%= f.text_area :description, rows: 3 %>
+      </div>
+    <% end %>
+
+    <%= render Panda::Core::Admin::FormFooterComponent.new(submit_text: "Create Category") %>
+  <% end %>
+<% end %>

--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -18,6 +18,24 @@
       <%= f.select :author_id, Panda::Core::User.admins.map { |u| [u.name, u.id] } %>
       <%= f.datetime_split_field :published_at %>
       <%= f.select :status, options_for_select([["Published", "published"], ["Unlisted", "unlisted"], ["Hidden", "hidden"], ["Archived", "archived"]], selected: post.status) %>
+
+      <div data-controller="category-select">
+        <%= f.select :post_category_id,
+            Panda::CMS::PostCategory.ordered.map { |c| [c.name, c.id] },
+            { label: "Category" },
+            data: { "category-select-target": "select" } %>
+        <button type="button"
+                class="mt-1 text-sm text-primary-600 hover:text-primary-800"
+                data-category-select-target="toggleButton"
+                data-action="click->category-select#toggleNewCategory">+ Add new category</button>
+        <div class="hidden mt-2" data-category-select-target="newCategoryFields">
+          <%= text_field_tag "post[new_category_name]", nil,
+              placeholder: "New category name",
+              autocomplete: "off",
+              class: "block w-full h-11 rounded-xl border border-gray-300 px-4 text-sm focus:border-primary-500 focus:ring-primary-500",
+              data: { "category-select-target": "newCategoryInput" } %>
+        </div>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/panda/cms/admin/posts/index.html.erb
+++ b/app/views/panda/cms/admin/posts/index.html.erb
@@ -12,6 +12,7 @@
         </span>
       </div>
     <% end %>
+    <% table.column("Category") { |post| render Panda::Core::Admin::TagComponent.new(text: post.post_category.name, status: :auto) } %>
     <% table.column("Status") { |post| render Panda::Core::Admin::TagComponent.new(status: post.status.to_sym) } %>
     <% table.column("Published") { |post| render Panda::Core::Admin::UserActivityComponent.new(at: post.published_at, user: post.author)} %>
     <% table.column("Last Updated") { |post| render Panda::Core::Admin::UserActivityComponent.new(at: post.updated_at)} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Panda::CMS::Engine.routes.draw do
         post :reorder, on: :member
       end
       resources :posts
+      resources :post_categories
       resources :redirects, except: :show
 
       get "settings", to: "settings#index"
@@ -72,6 +73,15 @@ Panda::CMS::Engine.routes.draw do
       as: :post,
       constraints: {
         slug: %r{[^/]+},
+        format: /html|json|xml/
+      }
+
+    # Route for category archive
+    get "#{Panda::CMS.config.posts[:prefix]}/category/:category_slug",
+      to: "posts#by_category",
+      as: :posts_by_category,
+      constraints: {
+        category_slug: /[a-z0-9-]+/,
         format: /html|json|xml/
       }
 

--- a/db/migrate/20260303000001_create_panda_cms_post_categories.rb
+++ b/db/migrate/20260303000001_create_panda_cms_post_categories.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreatePandaCMSPostCategories < ActiveRecord::Migration[8.1]
+  def up
+    create_table :panda_cms_post_categories, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :description
+      t.timestamps
+    end
+
+    add_index :panda_cms_post_categories, :name, unique: true
+    add_index :panda_cms_post_categories, :slug, unique: true
+
+    # Add nullable FK column first
+    add_reference :panda_cms_posts, :post_category, type: :uuid, foreign_key: {to_table: :panda_cms_post_categories}, null: true
+
+    # Seed default category and backfill
+    general = execute(<<~SQL).first
+      INSERT INTO panda_cms_post_categories (id, name, slug, created_at, updated_at)
+      VALUES (gen_random_uuid(), 'General', 'general', NOW(), NOW())
+      RETURNING id
+    SQL
+
+    execute(<<~SQL)
+      UPDATE panda_cms_posts SET post_category_id = '#{general["id"]}' WHERE post_category_id IS NULL
+    SQL
+
+    # Now make the column NOT NULL
+    change_column_null :panda_cms_posts, :post_category_id, false
+  end
+
+  def down
+    change_column_null :panda_cms_posts, :post_category_id, true
+    remove_reference :panda_cms_posts, :post_category
+    drop_table :panda_cms_post_categories
+  end
+end

--- a/lib/panda/cms/bulk_editor.rb
+++ b/lib/panda/cms/bulk_editor.rb
@@ -184,6 +184,11 @@ module Panda
             end
 
             begin
+              category = if post_data["post_category_slug"].present?
+                Panda::CMS::PostCategory.find_by(slug: post_data["post_category_slug"])
+              end
+              category ||= Panda::CMS::PostCategory.find_or_create_by!(name: "General") { |c| c.slug = "general" }
+
               post = Panda::CMS::Post.create!(
                 slug: slug,
                 title: post_data["title"],
@@ -191,6 +196,7 @@ module Panda
                 published_at: post_data["published_at"],
                 user: user,
                 author: author,
+                post_category: category,
                 content: post_data["content"] || "",
                 cached_content: post_data["cached_content"] || "",
                 # SEO fields
@@ -374,6 +380,7 @@ module Panda
             "published_at" => post.published_at&.iso8601,
             "user_email" => post.user&.email,
             "author_email" => post.author&.email,
+            "post_category_slug" => post.post_category&.slug,
             "content" => post.content,
             "cached_content" => post.cached_content
           }

--- a/lib/panda/cms/engine/core_config.rb
+++ b/lib/panda/cms/engine/core_config.rb
@@ -29,6 +29,7 @@ module Panda
                 content_children = [
                   {label: "Pages", path: "#{config.admin_path}/cms/pages"},
                   {label: "Posts", path: "#{config.admin_path}/cms/posts"},
+                  {label: "Post Categories", path: "#{config.admin_path}/cms/post_categories"},
                   {label: "Files", path: "#{config.admin_path}/cms/files"}
                 ]
 

--- a/lib/panda/cms/sanctuary_demo.rb
+++ b/lib/panda/cms/sanctuary_demo.rb
@@ -618,9 +618,10 @@ module Panda
           post.published_at = (data[:status] == "published") ? data[:slug_date] : nil
           post.seo_description = data[:seo_description]
 
-          # Assign demo user as author
+          # Assign demo user as author and default category
           post.user = @users[:admin] unless post.user_id
           post.author = @users[:admin] unless post.author_id
+          post.post_category ||= Panda::CMS::PostCategory.find_or_create_by!(name: "General") { |c| c.slug = "general" }
 
           post.save!
 

--- a/spec/dummy/db/migrate/20260303000001_create_panda_cms_post_categories.rb
+++ b/spec/dummy/db/migrate/20260303000001_create_panda_cms_post_categories.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreatePandaCMSPostCategories < ActiveRecord::Migration[8.1]
+  def up
+    create_table :panda_cms_post_categories, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :description
+      t.timestamps
+    end
+
+    add_index :panda_cms_post_categories, :name, unique: true
+    add_index :panda_cms_post_categories, :slug, unique: true
+
+    # Add nullable FK column first
+    add_reference :panda_cms_posts, :post_category, type: :uuid, foreign_key: {to_table: :panda_cms_post_categories}, null: true
+
+    # Seed default category and backfill
+    general = execute(<<~SQL).first
+      INSERT INTO panda_cms_post_categories (id, name, slug, created_at, updated_at)
+      VALUES (gen_random_uuid(), 'General', 'general', NOW(), NOW())
+      RETURNING id
+    SQL
+
+    execute(<<~SQL)
+      UPDATE panda_cms_posts SET post_category_id = '#{general["id"]}' WHERE post_category_id IS NULL
+    SQL
+
+    # Now make the column NOT NULL
+    change_column_null :panda_cms_posts, :post_category_id, false
+  end
+
+  def down
+    change_column_null :panda_cms_posts, :post_category_id, true
+    remove_reference :panda_cms_posts, :post_category
+    drop_table :panda_cms_post_categories
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_03_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -221,6 +221,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
     t.index ["workflow_status"], name: "index_panda_cms_pages_on_workflow_status"
   end
 
+  create_table "panda_cms_post_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_panda_cms_post_categories_on_name", unique: true
+    t.index ["slug"], name: "index_panda_cms_post_categories_on_slug", unique: true
+  end
+
   create_table "panda_cms_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "author_id"
     t.text "cached_content"
@@ -232,6 +242,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
     t.text "og_description"
     t.string "og_title"
     t.enum "og_type", default: "article", null: false, enum_type: "panda_cms_og_type"
+    t.uuid "post_category_id", null: false
     t.datetime "published_at"
     t.text "seo_description"
     t.enum "seo_index_mode", default: "visible", null: false, enum_type: "panda_cms_seo_index_mode"
@@ -245,6 +256,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
     t.string "workflow_status", default: "draft"
     t.index ["author_id"], name: "index_panda_cms_posts_on_author_id"
     t.index ["last_contributed_at"], name: "index_panda_cms_posts_on_last_contributed_at"
+    t.index ["post_category_id"], name: "index_panda_cms_posts_on_post_category_id"
     t.index ["slug"], name: "index_panda_cms_posts_on_slug", unique: true
     t.index ["status"], name: "index_panda_cms_posts_on_status"
     t.index ["user_id"], name: "index_panda_cms_posts_on_user_id"
@@ -508,6 +520,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
     t.index ["origin_path"], name: "index_panda_cms_redirects_on_origin_path"
   end
 
+  create_table "panda_cms_social_sharing_networks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "enabled", default: false, null: false
+    t.string "key", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_panda_cms_social_sharing_networks_on_key", unique: true
+    t.index ["position"], name: "index_panda_cms_social_sharing_networks_on_position"
+  end
+
   create_table "panda_cms_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "file_path"
@@ -649,6 +671,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_233859) do
   add_foreign_key "panda_cms_menus", "panda_cms_pages", column: "start_page_id"
   add_foreign_key "panda_cms_pages", "panda_cms_pages", column: "parent_id"
   add_foreign_key "panda_cms_pages", "panda_cms_templates"
+  add_foreign_key "panda_cms_posts", "panda_cms_post_categories", column: "post_category_id"
   add_foreign_key "panda_cms_posts", "panda_core_users", column: "author_id"
   add_foreign_key "panda_cms_posts", "panda_core_users", column: "user_id"
   add_foreign_key "panda_cms_pro_broken_links", "panda_cms_pro_link_checks", column: "link_check_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -520,16 +520,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_03_000001) do
     t.index ["origin_path"], name: "index_panda_cms_redirects_on_origin_path"
   end
 
-  create_table "panda_cms_social_sharing_networks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.boolean "enabled", default: false, null: false
-    t.string "key", null: false
-    t.integer "position", default: 0, null: false
-    t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_panda_cms_social_sharing_networks_on_key", unique: true
-    t.index ["position"], name: "index_panda_cms_social_sharing_networks_on_position"
-  end
-
   create_table "panda_cms_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "file_path"

--- a/spec/fixtures/panda_cms_post_categories.yml
+++ b/spec/fixtures/panda_cms_post_categories.yml
@@ -1,0 +1,11 @@
+general:
+  name: "General"
+  slug: "general"
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+news:
+  name: "News"
+  slug: "news"
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/spec/fixtures/panda_cms_posts.yml
+++ b/spec/fixtures/panda_cms_posts.yml
@@ -4,6 +4,7 @@ first_post:
   title: "Test Post 1"
   slug: '/<%= Time.current.strftime("%Y/%m") %>/test-post-1'
   status: "published"
+  post_category: general
   # User references removed - tests must set these programmatically
   published_at: <%= Time.current %>
   content: |-
@@ -34,6 +35,7 @@ second_post:
   title: "Test Post 2"
   slug: '/<%= Time.current.strftime("%Y/%m") %>/test-post-2'
   status: "hidden"
+  post_category: general
   # User references removed - tests must set these programmatically
   published_at: null
   content: |-

--- a/spec/helpers/panda/cms/posts_helper_spec.rb
+++ b/spec/helpers/panda/cms/posts_helper_spec.rb
@@ -51,12 +51,15 @@ RSpec.describe Panda::CMS::PostsHelper, type: :helper do
     end
 
     context "when there are published posts" do
+      let(:general_category) { Panda::CMS::PostCategory.find_or_create_by!(name: "General", slug: "general") }
+
       let!(:post_jan) do
         Panda::CMS::Post.create!(
           title: "January Post",
           slug: "/2024/01/january-post",
           user: admin_user,
           author: admin_user,
+          post_category: general_category,
           status: "published",
           published_at: Time.zone.parse("2024-01-15 12:00:00")
         )
@@ -68,6 +71,7 @@ RSpec.describe Panda::CMS::PostsHelper, type: :helper do
           slug: "/2024/02/february-post",
           user: admin_user,
           author: admin_user,
+          post_category: general_category,
           status: "published",
           published_at: Time.zone.parse("2024-02-20 12:00:00")
         )
@@ -79,6 +83,7 @@ RSpec.describe Panda::CMS::PostsHelper, type: :helper do
           slug: "/draft-post",
           user: admin_user,
           author: admin_user,
+          post_category: general_category,
           status: "hidden"
         )
       end
@@ -161,6 +166,7 @@ RSpec.describe Panda::CMS::PostsHelper, type: :helper do
             slug: "/2024/01/another-january-post",
             user: admin_user,
             author: admin_user,
+            post_category: general_category,
             status: "published",
             published_at: Time.zone.parse("2024-01-25 12:00:00")
           )

--- a/spec/helpers/panda/cms/seo_helper_spec.rb
+++ b/spec/helpers/panda/cms/seo_helper_spec.rb
@@ -41,12 +41,14 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
   end
 
   let(:admin_user) { create_admin_user }
+  let(:general_category) { Panda::CMS::PostCategory.find_or_create_by!(name: "General", slug: "general") }
   let(:test_post) do
     Panda::CMS::Post.create!(
       title: "Test Post",
       slug: "/test-post",
       user: admin_user,
       author: admin_user,
+      post_category: general_category,
       seo_title: "Post SEO Title",
       seo_description: "Post SEO description",
       og_title: "Post OG Title"

--- a/spec/lib/panda/cms/bulk_editor_spec.rb
+++ b/spec/lib/panda/cms/bulk_editor_spec.rb
@@ -40,11 +40,14 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
     Panda::CMS::Post.delete_all
 
     # Create posts with user reference
+    @general_category = Panda::CMS::PostCategory.find_or_create_by!(name: "General", slug: "general")
+
     @post1 = Panda::CMS::Post.create!(
       title: "Test Post 1",
       slug: "/#{Time.current.strftime("%Y/%m")}/test-post-1",
       status: "published",
       user: @user,
+      post_category: @general_category,
       published_at: Time.current
     )
 
@@ -53,6 +56,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
       slug: "/#{Time.current.strftime("%Y/%m")}/test-post-2",
       status: "hidden",
       user: @user,
+      post_category: @general_category,
       published_at: nil
     )
   end
@@ -579,6 +583,7 @@ RSpec.describe Panda::CMS::BulkEditor, type: :model do
       column_mappings = {
         "user_id" => "user_email",
         "author_id" => "author_email",
+        "post_category_id" => "post_category_slug",
         "og_image" => "og_image_url"
       }
 

--- a/spec/models/panda/cms/post_category_spec.rb
+++ b/spec/models/panda/cms/post_category_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::CMS::PostCategory, type: :model do
+  let(:admin_user) { create_admin_user }
+
+  describe "validations" do
+    it "requires a name" do
+      category = Panda::CMS::PostCategory.new(name: nil)
+      expect(category).not_to be_valid
+      expect(category.errors[:name]).to include("can't be blank")
+    end
+
+    it "requires a unique name" do
+      Panda::CMS::PostCategory.create!(name: "Unique Category")
+      duplicate = Panda::CMS::PostCategory.new(name: "Unique Category")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:name]).to include("has already been taken")
+    end
+
+    it "requires a unique slug" do
+      Panda::CMS::PostCategory.create!(name: "First", slug: "test-slug")
+      duplicate = Panda::CMS::PostCategory.new(name: "Second", slug: "test-slug")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:slug]).to include("has already been taken")
+    end
+
+    it "validates slug format" do
+      category = Panda::CMS::PostCategory.new(name: "Test", slug: "Invalid Slug!")
+      expect(category).not_to be_valid
+      expect(category.errors[:slug]).to include("must contain only lowercase letters, numbers, and hyphens")
+    end
+
+    it "accepts valid slug formats" do
+      category = Panda::CMS::PostCategory.new(name: "Test", slug: "valid-slug-123")
+      expect(category).to be_valid
+    end
+  end
+
+  describe "slug auto-generation" do
+    it "generates a slug from the name when slug is blank" do
+      category = Panda::CMS::PostCategory.new(name: "My Category")
+      category.valid?
+      expect(category.slug).to eq("my-category")
+    end
+
+    it "does not overwrite an existing slug" do
+      category = Panda::CMS::PostCategory.new(name: "My Category", slug: "custom-slug")
+      category.valid?
+      expect(category.slug).to eq("custom-slug")
+    end
+  end
+
+  describe "#deletable?" do
+    it "returns false for the general category" do
+      general = panda_cms_post_categories(:general)
+      expect(general.deletable?).to be false
+    end
+
+    it "returns true for other categories" do
+      news = panda_cms_post_categories(:news)
+      expect(news.deletable?).to be true
+    end
+  end
+
+  describe "dependent: :restrict_with_error" do
+    it "prevents deletion of a category with posts" do
+      category = Panda::CMS::PostCategory.create!(name: "Has Posts", slug: "has-posts")
+      Panda::CMS::Post.create!(
+        title: "Restrict Post",
+        slug: "/restrict-post",
+        user: admin_user,
+        author: admin_user,
+        post_category: category,
+        status: "published"
+      )
+
+      expect(category.destroy).to be false
+      expect(category.errors[:base]).to include("Cannot delete record because dependent posts exist")
+    end
+  end
+
+  describe ".ordered" do
+    it "orders categories by name" do
+      categories = Panda::CMS::PostCategory.ordered
+      expect(categories.map(&:name)).to eq(categories.map(&:name).sort)
+    end
+  end
+end

--- a/spec/models/panda/cms/post_spec.rb
+++ b/spec/models/panda/cms/post_spec.rb
@@ -3,6 +3,80 @@
 require "rails_helper"
 
 RSpec.describe Panda::CMS::Post, type: :model do
+  describe "associations" do
+    let(:admin_user) { create_admin_user }
+    let(:category) { Panda::CMS::PostCategory.create!(name: "Assoc Test", slug: "assoc-test") }
+
+    it "belongs to a post_category" do
+      post = Panda::CMS::Post.create!(
+        title: "Category Post",
+        slug: "/category-post",
+        user: admin_user,
+        author: admin_user,
+        post_category: category,
+        status: "published"
+      )
+      expect(post.post_category).to be_a(Panda::CMS::PostCategory)
+      expect(post.post_category).to eq(category)
+    end
+  end
+
+  describe ".by_category" do
+    let(:admin_user) { create_admin_user }
+    let(:general) { Panda::CMS::PostCategory.create!(name: "By Cat General", slug: "by-cat-general") }
+    let(:news) { Panda::CMS::PostCategory.create!(name: "By Cat News", slug: "by-cat-news") }
+
+    let!(:general_post) do
+      Panda::CMS::Post.create!(
+        title: "General Post",
+        slug: "/general-post",
+        user: admin_user,
+        author: admin_user,
+        post_category: general,
+        status: "published"
+      )
+    end
+
+    let!(:news_post) do
+      Panda::CMS::Post.create!(
+        title: "News Post",
+        slug: "/news-post",
+        user: admin_user,
+        author: admin_user,
+        post_category: news,
+        status: "published"
+      )
+    end
+
+    it "filters posts by category" do
+      results = Panda::CMS::Post.by_category(general)
+      expect(results).to include(general_post)
+      expect(results).not_to include(news_post)
+    end
+  end
+
+  describe ".with_category" do
+    let(:admin_user) { create_admin_user }
+    let(:category) { Panda::CMS::PostCategory.create!(name: "Eager Test", slug: "eager-test") }
+
+    let!(:post) do
+      Panda::CMS::Post.create!(
+        title: "Eager Post",
+        slug: "/eager-post",
+        user: admin_user,
+        author: admin_user,
+        post_category: category,
+        status: "published"
+      )
+    end
+
+    it "eager loads the post_category association" do
+      posts = Panda::CMS::Post.with_category.to_a
+      loaded_post = posts.find { |p| p.id == post.id }
+      expect(loaded_post.association(:post_category)).to be_loaded
+    end
+  end
+
   describe "editor content", :editorjs do
     let(:admin_user) { create_admin_user }
     let(:post) do
@@ -11,6 +85,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/test-post",
         user: admin_user,
         author: admin_user,
+        post_category: panda_cms_post_categories(:general),
         status: "published"
       )
     end
@@ -47,6 +122,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/active-post",
         user: admin_user,
         author: admin_user,
+        post_category: panda_cms_post_categories(:general),
         status: "published"
       )
     end
@@ -57,6 +133,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/draft-post",
         user: admin_user,
         author: admin_user,
+        post_category: panda_cms_post_categories(:general),
         status: "hidden"
       )
     end
@@ -67,6 +144,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/another-active-post",
         user: admin_user,
         author: admin_user,
+        post_category: panda_cms_post_categories(:general),
         status: "published"
       )
     end
@@ -112,6 +190,7 @@ RSpec.describe Panda::CMS::Post, type: :model do
         slug: "/test-post",
         user: admin_user,
         author: admin_user,
+        post_category: panda_cms_post_categories(:general),
         status: "published"
       )
     end

--- a/spec/requests/panda/cms/admin/post_categories_controller_spec.rb
+++ b/spec/requests/panda/cms/admin/post_categories_controller_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin Post Categories", type: :request do
+  fixtures :panda_cms_post_categories, :panda_cms_posts
+
+  let(:admin_user) { create_admin_user }
+  let(:general_category) { panda_cms_post_categories(:general) }
+  let(:news_category) { panda_cms_post_categories(:news) }
+
+  before do
+    post "/admin/test_sessions", params: {user_id: admin_user.id}
+  end
+
+  describe "GET /admin/cms/post_categories" do
+    it "returns a successful response" do
+      get "/admin/cms/post_categories"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists all categories" do
+      get "/admin/cms/post_categories"
+      expect(response.body).to include("General")
+      expect(response.body).to include("News")
+    end
+  end
+
+  describe "GET /admin/cms/post_categories/new" do
+    it "returns a successful response" do
+      get "/admin/cms/post_categories/new"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /admin/cms/post_categories" do
+    it "creates a new category" do
+      expect {
+        post "/admin/cms/post_categories", params: {
+          post_category: {name: "Tutorials"}
+        }
+      }.to change(Panda::CMS::PostCategory, :count).by(1)
+
+      category = Panda::CMS::PostCategory.find_by(name: "Tutorials")
+      expect(category.slug).to eq("tutorials")
+      expect(response).to redirect_to(edit_admin_cms_post_category_path(category))
+    end
+
+    it "rejects a category with a blank name" do
+      expect {
+        post "/admin/cms/post_categories", params: {
+          post_category: {name: ""}
+        }
+      }.not_to change(Panda::CMS::PostCategory, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "rejects a duplicate name" do
+      expect {
+        post "/admin/cms/post_categories", params: {
+          post_category: {name: "General"}
+        }
+      }.not_to change(Panda::CMS::PostCategory, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "GET /admin/cms/post_categories/:id/edit" do
+    it "returns a successful response" do
+      get "/admin/cms/post_categories/#{news_category.id}/edit"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("News")
+    end
+  end
+
+  describe "PATCH /admin/cms/post_categories/:id" do
+    it "updates a category" do
+      patch "/admin/cms/post_categories/#{news_category.id}", params: {
+        post_category: {name: "Latest News"}
+      }
+
+      expect(response).to redirect_to(edit_admin_cms_post_category_path(news_category))
+      expect(news_category.reload.name).to eq("Latest News")
+    end
+
+    it "rejects invalid updates" do
+      patch "/admin/cms/post_categories/#{news_category.id}", params: {
+        post_category: {name: ""}
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(news_category.reload.name).to eq("News")
+    end
+  end
+
+  describe "DELETE /admin/cms/post_categories/:id" do
+    it "prevents deletion of the default General category" do
+      expect {
+        delete "/admin/cms/post_categories/#{general_category.id}"
+      }.not_to change(Panda::CMS::PostCategory, :count)
+
+      expect(response).to redirect_to(admin_cms_post_categories_path)
+      follow_redirect!
+      expect(response.body).to include("default category cannot be deleted")
+    end
+
+    it "prevents deletion of a category with posts" do
+      category = Panda::CMS::PostCategory.create!(name: "With Posts")
+      Panda::CMS::Post.create!(
+        title: "Test Post",
+        slug: "/test-delete-category-post",
+        user: admin_user,
+        author: admin_user,
+        post_category: category,
+        status: "published"
+      )
+
+      expect {
+        delete "/admin/cms/post_categories/#{category.id}"
+      }.not_to change(Panda::CMS::PostCategory, :count)
+
+      expect(response).to redirect_to(admin_cms_post_categories_path)
+      follow_redirect!
+      expect(response.body).to include("Cannot delete a category that has posts")
+    end
+
+    it "deletes a category with no posts" do
+      category = Panda::CMS::PostCategory.create!(name: "Empty Category")
+
+      expect {
+        delete "/admin/cms/post_categories/#{category.id}"
+      }.to change(Panda::CMS::PostCategory, :count).by(-1)
+
+      expect(response).to redirect_to(admin_cms_post_categories_path)
+    end
+  end
+end

--- a/spec/support/cms.rb
+++ b/spec/support/cms.rb
@@ -17,6 +17,7 @@ module PandaCmsFixtures
   def self.get_class_name(fixture_set_name)
     case fixture_set_name
       # panda_core_users fixtures are not supported - users must be created programmatically
+    when "panda_cms_post_categories" then "Panda::CMS::PostCategory"
     when "panda_cms_posts" then "Panda::CMS::Post"
     when "panda_cms_pages" then "Panda::CMS::Page"
     when "panda_cms_templates" then "Panda::CMS::Template"

--- a/spec/system/panda/cms/admin/posts/edit_post_spec.rb
+++ b/spec/system/panda/cms/admin/posts/edit_post_spec.rb
@@ -9,12 +9,15 @@ RSpec.describe "Editing a post", type: :system do
     @regular = create_regular_user
 
     # Create post programmatically
+    @general_category = Panda::CMS::PostCategory.find_or_create_by!(name: "General", slug: "general")
+
     @post = Panda::CMS::Post.create!(
       title: "Test Post 1",
       slug: "/#{Time.current.strftime("%Y/%m")}/test-post-1",
       status: "published",
       user: @admin,
       author: @admin,
+      post_category: @general_category,
       published_at: Time.current,
       content: {
         "time" => Time.current.to_i * 1000,


### PR DESCRIPTION
## Summary

- Adds a `panda_cms_post_categories` table with UUID PK; each post now `belongs_to :post_category` (default: "General")
- Admin CRUD for categories at `/admin/cms/post_categories` with ViewComponent-based index/new/edit pages
- Inline "Add new category" toggle on the post form via a `category-select` Stimulus controller
- Public route `/blog/category/:slug` for filtering posts by category with HTTP caching
- Category column added to admin posts index, navigation item under "Content" group
- BulkEditor and SanctuaryDemo updated for the new required association
- Migration backfills all existing posts to "General" category before setting NOT NULL

## New files

| File | Purpose |
|------|---------|
| `db/migrate/20260303000001_create_panda_cms_post_categories.rb` | Migration (table + FK + backfill) |
| `app/models/panda/cms/post_category.rb` | Model with validations, slug generation, `deletable?` |
| `app/controllers/panda/cms/admin/post_categories_controller.rb` | Admin CRUD controller |
| `app/views/panda/cms/admin/post_categories/{index,new,edit}.html.erb` | Admin views |
| `app/javascript/panda/cms/controllers/category_select_controller.js` | Stimulus controller |
| `spec/fixtures/panda_cms_post_categories.yml` | Test fixtures |
| `spec/models/panda/cms/post_category_spec.rb` | Model spec (11 examples) |

## Test plan

- [x] 820 examples, 0 failures (`bundle exec rspec`)
- [x] 0 standardrb offenses
- [x] All pre-commit hooks pass (brakeman, bundle-audit, erblint, standardrb, zeitwerk)
- [ ] CI green
- [ ] Manual: admin can create/edit/delete categories (except "General")
- [ ] Manual: post form shows category dropdown with inline create
- [ ] Manual: `/blog/category/general` filters posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)