### PR TITLE
fix: Preload page_menu in MenuComponent to prevent N+1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.1)
+    json (2.19.0)
     jwt (2.10.2)
       base64
     language_server-protocol (3.17.0.5)

--- a/app/components/panda/cms/menu_component.rb
+++ b/app/components/panda/cms/menu_component.rb
@@ -49,7 +49,8 @@ module Panda
         end
 
         # Re-preload :page associations lost during Marshal deserialization from cache
-        ActiveRecord::Associations::Preloader.new(records: menu_items, associations: :page).call
+        # Include :page_menu so PageMenuComponent doesn't trigger N+1 for each menu item
+        ActiveRecord::Associations::Preloader.new(records: menu_items, associations: {page: :page_menu}).call
 
         # Filter menu items based on overrides
         filtered_menu_items = if @overrides[:hidden_items].present?

--- a/app/components/panda/cms/menu_component.rb
+++ b/app/components/panda/cms/menu_component.rb
@@ -49,8 +49,9 @@ module Panda
         end
 
         # Re-preload :page associations lost during Marshal deserialization from cache
-        # Include :page_menu so PageMenuComponent doesn't trigger N+1 for each menu item
-        ActiveRecord::Associations::Preloader.new(records: menu_items, associations: {page: :page_menu}).call
+        # Conditionally include :page_menu so PageMenuComponent doesn't trigger N+1 for each menu item
+        associations = @render_page_menu ? { page: :page_menu } : :page
+        ActiveRecord::Associations::Preloader.new(records: menu_items, associations: associations).call
 
         # Filter menu items based on overrides
         filtered_menu_items = if @overrides[:hidden_items].present?


### PR DESCRIPTION
## Summary
- The `MenuComponent` was preloading `:page` but not `:page_menu`, causing an N+1 query on every page render when `PageMenuComponent` checks for sub-navigation
- Added `{page: :page_menu}` to the `ActiveRecord::Associations::Preloader` call

## Test plan
- [ ] Verify page renders without N+1 on page_menu (Bullet or query logs)
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)