### PR TITLE
Move Post Categories from Content to Settings

### DIFF
--- a/lib/panda/cms/engine/core_config.rb
+++ b/lib/panda/cms/engine/core_config.rb
@@ -29,7 +29,6 @@ module Panda
                 content_children = [
                   {label: "Pages", path: "#{config.admin_path}/cms/pages"},
                   {label: "Posts", path: "#{config.admin_path}/cms/posts"},
-                  {label: "Post Categories", path: "#{config.admin_path}/cms/post_categories"},
                   {label: "Files", path: "#{config.admin_path}/cms/files"}
                 ]
 
@@ -70,6 +69,7 @@ module Panda
                   icon: "fa-solid fa-gear",
                   children: [
                     {label: "Users", path: "#{config.admin_path}/users"},
+                    {label: "Post Categories", path: "#{config.admin_path}/cms/post_categories"},
                     {label: "Social Sharing", path: "#{config.admin_path}/cms/settings/social_sharing"},
                     {label: "System Status", path: "#{config.admin_path}/cms/settings"}
                   ]


### PR DESCRIPTION
## Summary
- Moves "Post Categories" nav item from the Content section to Settings
- Post categories are a configuration/taxonomy concern, not a daily content operation

## Test plan
- [ ] Verify Post Categories appears under Settings in admin sidebar
- [ ] Verify Post Categories link still works correctly
- [ ] Check Content section now shows Pages, Posts, Files (and Collections if enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)