### PR TITLE
Add permission: keys to base navigation items

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: d6efa21219a22b4edf0abad46963f0c1bfb668a3
+  revision: 14de4f2bac31db5b04a5cf7403e73031f7d191a6
   branch: main
   specs:
     panda-core (0.14.4)

--- a/app/components/panda/cms/menu_component.rb
+++ b/app/components/panda/cms/menu_component.rb
@@ -50,7 +50,7 @@ module Panda
 
         # Re-preload :page associations lost during Marshal deserialization from cache
         # Conditionally include :page_menu so PageMenuComponent doesn't trigger N+1 for each menu item
-        associations = @render_page_menu ? { page: :page_menu } : :page
+        associations = @render_page_menu ? {page: :page_menu} : :page
         ActiveRecord::Associations::Preloader.new(records: menu_items, associations: associations).call
 
         # Filter menu items based on overrides

--- a/app/controllers/panda/cms/admin/settings/social_sharing_controller.rb
+++ b/app/controllers/panda/cms/admin/settings/social_sharing_controller.rb
@@ -34,7 +34,7 @@ module Panda
               view_paths = Rails.root.join("app", "views").to_s
               Dir.glob("#{view_paths}/**/*.erb").any? { |f| File.read(f).include?("panda_social_sharing") }
             end
-          rescue StandardError
+          rescue
             false
           end
         end

--- a/lib/panda/cms/engine/core_config.rb
+++ b/lib/panda/cms/engine/core_config.rb
@@ -60,7 +60,7 @@ module Panda
                   label: "Tools",
                   icon: "fa-solid fa-wrench",
                   children: [
-                    {label: "Import/Export", path: "#{config.admin_path}/cms/tools/import-export"}
+                    {label: "Import/Export", path: "#{config.admin_path}/cms/tools/import-export", permission: :manage_settings}
                   ]
                 }
 
@@ -68,8 +68,9 @@ module Panda
                 items << {
                   label: "Settings",
                   icon: "fa-solid fa-gear",
+                  permission: :manage_settings,
                   children: [
-                    {label: "Users", path: "#{config.admin_path}/users"},
+                    {label: "Users", path: "#{config.admin_path}/users", permission: :manage_users},
                     {label: "Social Sharing", path: "#{config.admin_path}/cms/settings/social_sharing"},
                     {label: "System Status", path: "#{config.admin_path}/cms/settings"}
                   ]


### PR DESCRIPTION
## Summary
- Adds `permission: :manage_settings` to the Settings navigation section
- Adds `permission: :manage_users` to the Users child item within Settings
- Adds `permission: :manage_settings` to the Import/Export child item within Tools

These declarative `permission:` keys are processed by Core's `NavigationRegistry.apply_permission_visibility!` during build, converting them to visibility lambdas that check `config.authorization_policy`. Without Pro loaded, the default policy is `user.admin?` — so behavior is unchanged for non-Pro installs.

## Dependencies
- **Requires**: panda-core#139 (PermissionRegistry + NavigationRegistry permission: support)
- **Used by**: panda-cms-pro refactor-rbac-to-core-registry branch

## Test plan
- [ ] Verify admin users see all navigation items as before
- [ ] Verify non-admin users (with Pro + roles) see filtered navigation
- [ ] Verify Settings section is hidden for users without `manage_settings` permission
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)