### PR TITLE
Add image upload tool to EditorJS configurations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/tastybamboo/panda-core.git
-  revision: 030cee9dda75ea001ddeab99f4ba42631ce51cfb
+  revision: b8ebdb97d06d47e1b0389c9514a478899754d2ec
   branch: main
   specs:
     panda-core (0.14.4)
+      csv
       image_processing (~> 1.2)
       importmap-rails
       omniauth
@@ -15,6 +16,7 @@ GIT
       turbo-rails
       view_component (~> 4.2)
       webrick
+      xsv (~> 1.0)
 
 GIT
   remote: https://github.com/tastybamboo/panda-editor.git
@@ -175,6 +177,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     cuprite (0.17)
       capybara (~> 3.0)
       ferrum (~> 0.17.0)
@@ -425,14 +428,14 @@ GEM
     rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (8.0.3)
+    rspec-rails (8.0.4)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       railties (>= 7.2)
-      rspec-core (~> 3.13)
-      rspec-expectations (~> 3.13)
-      rspec-mocks (~> 3.13)
-      rspec-support (~> 3.13)
+      rspec-core (>= 3.13.0, < 5.0.0)
+      rspec-expectations (>= 3.13.0, < 5.0.0)
+      rspec-mocks (>= 3.13.0, < 5.0.0)
+      rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
     rubocop (1.84.2)
       json (~> 2.3)
@@ -445,7 +448,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -469,6 +472,7 @@ GEM
     ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
+    rubyzip (3.2.2)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -522,7 +526,7 @@ GEM
     tailwindcss-ruby (4.2.0-arm64-darwin)
     tailwindcss-ruby (4.2.0-x86_64-linux-gnu)
     thor (1.5.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
@@ -549,6 +553,8 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    xsv (1.4.0)
+      rubyzip (>= 1.3, < 4)
     yard (0.9.38)
     yard-activerecord (0.0.17)
       activesupport

--- a/app/components/panda/cms/rich_text_component.rb
+++ b/app/components/panda/cms/rich_text_component.rb
@@ -280,7 +280,7 @@ module Panda
             "editable-initialized": "false",
             "editable-version": "2.28.2",
             "editable-autosave": "false",
-            "editable-tools": '{"paragraph":true,"header":true,"list":true,"quote":true,"table":true}',
+            "editable-tools": '{"paragraph":true,"header":true,"list":true,"quote":true,"table":true,"image":true}',
             "editable-kind": "rich_text",
             "editable-block-content-id": @block_content_id,
             "editable-page-id": Current.page.id,

--- a/app/javascript/panda/cms/controllers/editor_form_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_form_controller.js
@@ -138,6 +138,20 @@ export default class extends Controller {
             class: window.Table,
             inlineToolbar: true
           },
+          image: {
+            class: window.ImageTool,
+            inlineToolbar: true,
+            config: {
+              endpoints: {
+                byFile: window.PANDA_CMS_EDITOR_JS_ENDPOINTS?.fileUpload
+              },
+              field: 'image',
+              types: 'image/*',
+              additionalRequestHeaders: {
+                'X-CSRF-Token': csrfToken
+              }
+            }
+          },
           linkTool: {
             class: window.LinkTool,
             config: {

--- a/app/javascript/panda/cms/controllers/editor_iframe_controller.js
+++ b/app/javascript/panda/cms/controllers/editor_iframe_controller.js
@@ -369,7 +369,7 @@ export default class extends Controller {
         'header': 'Header',
         'nested-list': 'NestedList',
         'quote': 'Quote',
-        'simple-image': 'SimpleImage',
+        'image': 'ImageTool',
         'table': 'Table',
         'embed': 'Embed',
         'link': 'LinkTool',


### PR DESCRIPTION
## Summary

- Add `@editorjs/image` tool config to the form editor controller (`editor_form_controller.js`)
- Update iframe editor tool mapping from `SimpleImage` to `ImageTool` (`editor_iframe_controller.js`)
- Enable the image tool in the rich text component's editable tools list (`rich_text_component.rb`)
- Update Gemfile.lock with latest dependency versions

## Related

- Depends on panda-editor PR: tastybamboo/panda-editor#21 (CDN swap + renderer changes)
- No backend changes needed — `FilesController#create_from_editor` already handles `params[:image]` and returns the expected `{ success: true, file: { url: ... } }` response

## Test plan

- [x] All lefthook checks pass (brakeman, bundle-audit, erblint, standardrb, zeitwerk)
- [ ] Manual: upload an image in both the page editor (iframe) and form editor contexts
- [ ] Manual: verify CSRF token is sent with upload requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)