### PR TITLE
Add post-commit hook to auto-update outdated gems

### DIFF
--- a/bin/bundle-auto-update
+++ b/bin/bundle-auto-update
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# bundle-auto-update — post-commit hook script
+#
+# After a commit completes, checks for outdated gems and creates
+# a follow-up commit with `bundle update --all` if needed.
+#
+# Designed to be called from lefthook post-commit.
+# Always exits 0 — post-commit hooks should never fail the commit.
+
+set -euo pipefail
+
+# ── Guard: recursion ─────────────────────────────────────────────
+if [[ "${BUNDLE_AUTO_UPDATE_RUNNING:-}" == "1" ]]; then
+  exit 0
+fi
+export BUNDLE_AUTO_UPDATE_RUNNING=1
+
+# ── Trap: always exit 0 ─────────────────────────────────────────
+cleanup() { exit 0; }
+trap cleanup EXIT ERR INT TERM
+
+# ── Guard: not a Ruby project ───────────────────────────────────
+if [[ ! -f Gemfile ]]; then
+  exit 0
+fi
+
+# ── Guard: Gemfile.lock not tracked by git ──────────────────────
+if ! git ls-files --error-unmatch Gemfile.lock &>/dev/null; then
+  exit 0
+fi
+
+# ── Guard: rebase or merge in progress ──────────────────────────
+git_dir="$(git rev-parse --git-dir 2>/dev/null)"
+if [[ -d "${git_dir}/rebase-merge" ]] || [[ -d "${git_dir}/rebase-apply" ]] || [[ -f "${git_dir}/MERGE_HEAD" ]]; then
+  exit 0
+fi
+
+# ── Guard: Gemfile.lock has unstaged changes ────────────────────
+if ! git diff --quiet -- Gemfile.lock 2>/dev/null; then
+  exit 0
+fi
+
+# ── Check for outdated gems ─────────────────────────────────────
+echo "🔍 Checking for outdated gems..."
+if bundle outdated --parseable 2>/dev/null | grep -q .; then
+  echo "📦 Outdated gems found — running bundle update --all..."
+  bundle update --all
+
+  # Only commit if Gemfile.lock actually changed
+  if ! git diff --quiet -- Gemfile.lock 2>/dev/null; then
+    git add Gemfile.lock
+    LEFTHOOK=0 git commit -m "$(cat <<'EOF'
+chore: bundle update (auto-update outdated gems)
+EOF
+)"
+    echo "✅ Auto-update commit created."
+  else
+    echo "✅ Gemfile.lock unchanged after update — nothing to commit."
+  fi
+else
+  echo "✅ All gems up to date."
+fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,14 +1,16 @@
 ---
 assert_lefthook_installed: true
 colors: true
+post-commit:
+  jobs:
+    - name: auto-bundle-update
+      run: bash bin/bundle-auto-update
 pre-commit:
   jobs:
     - name: brakeman
       run: brakeman --no-pager --no-progress --quiet
     - name: bundle-audit
       run: bundle exec bundle-audit update && bundle exec bundle-audit check
-    - name: bundle-outdated
-      run: bundle outdated --strict
     - name: erblint
       run: bundle exec erb_lint app/views --lint-all
     - name: standardrb


### PR DESCRIPTION
## Summary
- Adds `bin/bundle-auto-update` post-commit hook that automatically runs `bundle update --all` when gems are outdated
- Removes the `bundle-outdated` pre-commit check that blocked commits (replaced by the auto-fix approach)
- Hook creates a separate follow-up commit with the updated Gemfile.lock

## Test plan
- [ ] Make a code change and commit — observe post-commit output checking for outdated gems
- [ ] If gems are outdated, verify a separate auto-update commit is created
- [ ] Verify the auto-update commit doesn't trigger another auto-update (recursion guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)