### PR TITLE
Fix CodeComponent rendering raw JSON for EditorJS content

### DIFF
--- a/app/components/panda/cms/code_component.rb
+++ b/app/components/panda/cms/code_component.rb
@@ -36,7 +36,13 @@ module Panda
         return false if block.nil?
 
         @block_content_obj = find_block_content(block)
-        @code_content = @block_content_obj&.content.to_s
+        content = @block_content_obj&.content
+        # If content is EditorJS data (Hash), use the pre-rendered cached_content instead
+        @code_content = if content.is_a?(Hash)
+          @block_content_obj&.cached_content.to_s
+        else
+          content.to_s
+        end
         @block_content_id = @block_content_obj&.id
       end
 

--- a/spec/components/panda/cms/code_component_spec.rb
+++ b/spec/components/panda/cms/code_component_spec.rb
@@ -52,5 +52,29 @@ RSpec.describe Panda::CMS::CodeComponent, type: :component do
       output = render_inline(component)
       expect(output.to_html).to include("<p>Test HTML</p>")
     end
+
+    context "when content is EditorJS JSON" do
+      before do
+        editorjs_json = {
+          "time" => 1773316550000,
+          "blocks" => [
+            {"data" => {"text" => "Hello world"}, "type" => "paragraph"}
+          ],
+          "version" => "2.28.2"
+        }.to_json
+
+        @block_content.update_columns(
+          content: editorjs_json,
+          cached_content: "<p>Hello world</p>"
+        )
+      end
+
+      it "renders cached_content instead of raw JSON" do
+        component = described_class.new(key: :test_code, editable: false)
+        output = render_inline(component)
+        expect(output.to_html).to include("<p>Hello world</p>")
+        expect(output.to_html).not_to include("blocks")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- When a `code` block's content is edited through the CMS editor, it gets saved as EditorJS JSON. The `Panda::Editor::Content` mixin auto-parses this into a Ruby Hash on read.
- `CodeComponent` was calling `.to_s` on the Hash, producing raw Ruby Hash notation (`{"time" => ..., "blocks" => [...]}`) instead of rendered HTML.
- Now `CodeComponent` checks if content is a Hash (EditorJS data) and falls back to the pre-rendered `cached_content`, which contains properly rendered HTML.

## Test plan
- [x] Existing CodeComponent specs pass
- [x] New spec verifies EditorJS content renders `cached_content` instead of raw JSON
- [ ] Verify on staging: `/legal/data-processors` renders formatted HTML after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)