### PR TITLE
Fix ActiveStorage variant URL and harden excerpt

### DIFF
--- a/app/helpers/panda/cms/seo_helper.rb
+++ b/app/helpers/panda/cms/seo_helper.rb
@@ -29,7 +29,7 @@ module Panda
 
         # Open Graph image
         if resource.og_image.attached?
-          og_image_url = url_for(resource.og_image.variant(:og_share))
+          og_image_url = rails_representation_url(resource.og_image.variant(:og_share))
           tags << tag.meta(property: "og:image", content: og_image_url)
           tags << tag.meta(property: "og:image:width", content: "1200")
           tags << tag.meta(property: "og:image:height", content: "630")
@@ -42,7 +42,7 @@ module Panda
 
         # Twitter image (same as OG)
         if resource.og_image.attached?
-          tags << tag.meta(name: "twitter:image", content: url_for(resource.og_image.variant(:og_share)))
+          tags << tag.meta(name: "twitter:image", content: rails_representation_url(resource.og_image.variant(:og_share)))
         end
 
         safe_join(tags, "\n")

--- a/app/models/panda/cms/post.rb
+++ b/app/models/panda/cms/post.rb
@@ -116,7 +116,8 @@ module Panda
         text = if content.is_a?(Hash) && content["blocks"]
           content["blocks"]
             .select { |block| block["type"] == "paragraph" }
-            .map { |block| block["data"]["text"] }
+            .map { |block| block.dig("data", "text") }
+            .compact
             .join(" ")
         else
           content.to_s

--- a/app/models/panda/cms/post.rb
+++ b/app/models/panda/cms/post.rb
@@ -115,9 +115,9 @@ module Panda
 
         text = if content.is_a?(Hash) && content["blocks"]
           content["blocks"]
-            .select { |block| block["type"] == "paragraph" }
+            .select { |block| block.is_a?(Hash) && block["type"] == "paragraph" }
             .map { |block| block.dig("data", "text") }
-            .compact
+            .select { |value| value.is_a?(String) }
             .join(" ")
         else
           content.to_s

--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -94,7 +94,7 @@
         } %>
         <% if f.object.present? && f.object.persisted? && f.object.og_image.attached? %>
           <div class="mt-2">
-            <%= image_tag url_for(f.object.og_image.variant(:og_share)), class: "max-w-xs rounded border border-gray-300" %>
+            <%= image_tag f.object.og_image.variant(:og_share), class: "max-w-xs rounded border border-gray-300" %>
           </div>
         <% end %>
       </div>

--- a/spec/helpers/panda/cms/seo_helper_spec.rb
+++ b/spec/helpers/panda/cms/seo_helper_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
         allow(test_page).to receive_message_chain(:og_image, :variant).and_return(
           double(url: "https://example.com/image.jpg")
         )
-        allow(helper).to receive(:url_for).and_return("https://example.com/image.jpg")
+        allow(helper).to receive(:rails_representation_url).and_return("https://example.com/image.jpg")
 
         result = helper.render_seo_meta_tags(test_page)
         expect(result).to include('property="og:image"')

--- a/spec/models/panda/cms/post_spec.rb
+++ b/spec/models/panda/cms/post_spec.rb
@@ -257,6 +257,38 @@ RSpec.describe Panda::CMS::Post, type: :model do
       end
     end
 
+    describe "#excerpt" do
+      it "extracts text from paragraph blocks" do
+        post.content = {
+          "blocks" => [
+            {"type" => "paragraph", "data" => {"text" => "Hello world"}},
+            {"type" => "paragraph", "data" => {"text" => "Second paragraph"}}
+          ]
+        }
+        expect(post.excerpt(200)).to include("Hello world")
+        expect(post.excerpt(200)).to include("Second paragraph")
+      end
+
+      it "handles blocks with missing data or text keys" do
+        post.content = {
+          "blocks" => [
+            {"type" => "paragraph", "data" => {"text" => "Valid block"}},
+            {"type" => "paragraph", "data" => {}},
+            {"type" => "paragraph"},
+            {"type" => "paragraph", "data" => {"text" => "Another valid block"}}
+          ]
+        }
+        expect { post.excerpt }.not_to raise_error
+        expect(post.excerpt(200)).to include("Valid block")
+        expect(post.excerpt(200)).to include("Another valid block")
+      end
+
+      it "returns empty string when content is blank" do
+        post.content = nil
+        expect(post.excerpt).to eq("")
+      end
+    end
+
     describe "#effective_og_title" do
       it "returns og_title when present" do
         post.og_title = "Custom OG Title"


### PR DESCRIPTION
## Summary
- Replace `url_for` with direct variant in `image_tag` for OG image preview in admin post form — fixes crash in Rails 8.1 where `VariantWithRecord` no longer responds to `to_model`
- Use `dig` for safe nested hash access in `Post#excerpt` to prevent `NoMethodError` on malformed EditorJS blocks

## Context
Blog posts with OG images attached cause a 500 error on both the public page and admin edit form. `url_for(variant)` relies on `to_model` for polymorphic routing, but `ActiveStorage::VariantWithRecord` dropped this method in Rails 8.1.

The neurobetter-side fix (structured data template) is in a separate PR: neurobetter/neurobetter#244 (pending)

## Test plan
- [ ] Visit a blog post with an OG image attached — should render without error
- [ ] Edit a post with an OG image in admin — form should load and show preview
- [ ] Create a post without an OG image — should work as before
- [ ] Verify `Post#excerpt` handles blocks with missing `data` or `text` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)