### PR TITLE
Fix ActiveStorage variant URL generation for Rails 8.1

### DIFF
--- a/app/helpers/panda/cms/seo_helper.rb
+++ b/app/helpers/panda/cms/seo_helper.rb
@@ -68,25 +68,18 @@ module Panda
 
       private
 
-      #
-      # Generates the full canonical URL for a resource
-      #
-      # @param resource [Panda::CMS::Page, Panda::CMS::Post] The page or post
-      # @return [String] Full canonical URL
-      # @visibility private
-      #
-      # Generates a URL for an ActiveStorage variant.
+      # Generates a URL for an ActiveStorage variant, compatible with both Rails 7.x and 8.1+.
       # In Rails 8.1+, url_for(variant) broke because VariantWithRecord dropped to_model,
       # and rails_representation_url was renamed to rails_blob_representation_proxy_url.
-      # This method handles both Rails 7.x and 8.1+ APIs.
+      # Avoids eager processing — uses variant.blob and variant.variation directly so the
+      # variant is only processed lazily when the representation URL is requested by a client.
       def variant_representation_url(variant)
         if respond_to?(:rails_blob_representation_proxy_url)
           # Rails 8.1+
-          processed = variant.processed
           rails_blob_representation_proxy_url(
-            processed.blob.signed_id,
-            processed.variation.key,
-            processed.blob.filename
+            variant.blob.signed_id,
+            variant.variation.key,
+            variant.blob.filename
           )
         else
           # Rails 7.x
@@ -97,6 +90,13 @@ module Panda
         nil
       end
 
+      #
+      # Generates the full canonical URL for a resource
+      #
+      # @param resource [Panda::CMS::Page, Panda::CMS::Post] The page or post
+      # @return [String] Full canonical URL
+      # @visibility private
+      #
       def canonical_url_for(resource)
         # If canonical_url is a full URL, use it as-is
         return resource.canonical_url if resource.canonical_url&.match?(%r{\Ahttps?://})

--- a/app/helpers/panda/cms/seo_helper.rb
+++ b/app/helpers/panda/cms/seo_helper.rb
@@ -27,26 +27,21 @@ module Panda
         tags << tag.meta(property: "og:type", content: resource.og_type)
         tags << tag.meta(property: "og:url", content: canonical_url_for(resource))
 
+        # Image URL for OG and Twitter (compute once)
+        og_image_url = variant_representation_url(resource.og_image.variant(:og_share)) if resource.og_image.attached?
+
         # Open Graph image
-        if resource.og_image.attached?
-          og_image_url = variant_representation_url(resource.og_image.variant(:og_share))
-          if og_image_url
-            tags << tag.meta(property: "og:image", content: og_image_url)
-            tags << tag.meta(property: "og:image:width", content: "1200")
-            tags << tag.meta(property: "og:image:height", content: "630")
-          end
+        if og_image_url
+          tags << tag.meta(property: "og:image", content: og_image_url)
+          tags << tag.meta(property: "og:image:width", content: "1200")
+          tags << tag.meta(property: "og:image:height", content: "630")
         end
 
         # Twitter Card tags (with fallback to OG)
         tags << tag.meta(name: "twitter:card", content: "summary_large_image")
         tags << tag.meta(name: "twitter:title", content: resource.effective_og_title)
         tags << tag.meta(name: "twitter:description", content: resource.effective_og_description) if resource.effective_og_description.present?
-
-        # Twitter image (same as OG)
-        if resource.og_image.attached?
-          twitter_url = variant_representation_url(resource.og_image.variant(:og_share))
-          tags << tag.meta(name: "twitter:image", content: twitter_url) if twitter_url
-        end
+        tags << tag.meta(name: "twitter:image", content: og_image_url) if og_image_url
 
         safe_join(tags, "\n")
       end

--- a/app/helpers/panda/cms/seo_helper.rb
+++ b/app/helpers/panda/cms/seo_helper.rb
@@ -29,10 +29,12 @@ module Panda
 
         # Open Graph image
         if resource.og_image.attached?
-          og_image_url = rails_representation_url(resource.og_image.variant(:og_share))
-          tags << tag.meta(property: "og:image", content: og_image_url)
-          tags << tag.meta(property: "og:image:width", content: "1200")
-          tags << tag.meta(property: "og:image:height", content: "630")
+          og_image_url = variant_representation_url(resource.og_image.variant(:og_share))
+          if og_image_url
+            tags << tag.meta(property: "og:image", content: og_image_url)
+            tags << tag.meta(property: "og:image:width", content: "1200")
+            tags << tag.meta(property: "og:image:height", content: "630")
+          end
         end
 
         # Twitter Card tags (with fallback to OG)
@@ -42,7 +44,8 @@ module Panda
 
         # Twitter image (same as OG)
         if resource.og_image.attached?
-          tags << tag.meta(name: "twitter:image", content: rails_representation_url(resource.og_image.variant(:og_share)))
+          twitter_url = variant_representation_url(resource.og_image.variant(:og_share))
+          tags << tag.meta(name: "twitter:image", content: twitter_url) if twitter_url
         end
 
         safe_join(tags, "\n")
@@ -72,6 +75,20 @@ module Panda
       # @return [String] Full canonical URL
       # @visibility private
       #
+      # Generates a URL for an ActiveStorage variant, handling Rails 8.1+ API changes
+      # where url_for no longer works with VariantWithRecord (missing to_model).
+      def variant_representation_url(variant)
+        processed = variant.processed
+        rails_blob_representation_proxy_url(
+          processed.blob.signed_id,
+          processed.variation.key,
+          processed.blob.filename
+        )
+      rescue NoMethodError, ActionController::UrlGenerationError => e
+        Rails.logger.warn "[Panda CMS] Failed to generate variant URL: #{e.message}"
+        nil
+      end
+
       def canonical_url_for(resource)
         # If canonical_url is a full URL, use it as-is
         return resource.canonical_url if resource.canonical_url&.match?(%r{\Ahttps?://})

--- a/app/helpers/panda/cms/seo_helper.rb
+++ b/app/helpers/panda/cms/seo_helper.rb
@@ -75,15 +75,23 @@ module Panda
       # @return [String] Full canonical URL
       # @visibility private
       #
-      # Generates a URL for an ActiveStorage variant, handling Rails 8.1+ API changes
-      # where url_for no longer works with VariantWithRecord (missing to_model).
+      # Generates a URL for an ActiveStorage variant.
+      # In Rails 8.1+, url_for(variant) broke because VariantWithRecord dropped to_model,
+      # and rails_representation_url was renamed to rails_blob_representation_proxy_url.
+      # This method handles both Rails 7.x and 8.1+ APIs.
       def variant_representation_url(variant)
-        processed = variant.processed
-        rails_blob_representation_proxy_url(
-          processed.blob.signed_id,
-          processed.variation.key,
-          processed.blob.filename
-        )
+        if respond_to?(:rails_blob_representation_proxy_url)
+          # Rails 8.1+
+          processed = variant.processed
+          rails_blob_representation_proxy_url(
+            processed.blob.signed_id,
+            processed.variation.key,
+            processed.blob.filename
+          )
+        else
+          # Rails 7.x
+          url_for(variant)
+        end
       rescue NoMethodError, ActionController::UrlGenerationError => e
         Rails.logger.warn "[Panda CMS] Failed to generate variant URL: #{e.message}"
         nil

--- a/spec/helpers/panda/cms/seo_helper_spec.rb
+++ b/spec/helpers/panda/cms/seo_helper_spec.rb
@@ -141,15 +141,16 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
     end
 
     context "with og_image attached" do
-      it "renders og:image tags with dimensions" do
-        # Mock the og_image attachment and variant processing chain
-        blob_double = double(signed_id: "signed_id", filename: "image.jpg")
-        variation_double = double(key: "variant_key")
-        processed_double = double(blob: blob_double, variation: variation_double)
-        variant_double = double(processed: processed_double)
+      let(:blob_double) { double(signed_id: "signed_id", filename: "image.jpg") }
+      let(:variation_double) { double(key: "variant_key") }
+      let(:variant_double) { double(blob: blob_double, variation: variation_double) }
 
+      before do
         allow(test_page).to receive_message_chain(:og_image, :attached?).and_return(true)
         allow(test_page).to receive_message_chain(:og_image, :variant).and_return(variant_double)
+      end
+
+      it "renders og:image tags with dimensions" do
         allow(helper).to receive(:rails_blob_representation_proxy_url).and_return("https://example.com/image.jpg")
 
         result = helper.render_seo_meta_tags(test_page)
@@ -160,6 +161,17 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
         expect(result).to include('property="og:image:height"')
         expect(result).to include("630")
         expect(result).to include('name="twitter:image"')
+      end
+
+      it "gracefully skips image tags when URL generation fails" do
+        allow(helper).to receive(:rails_blob_representation_proxy_url)
+          .and_raise(ActionController::UrlGenerationError.new("missing keys"))
+        allow(Rails.logger).to receive(:warn)
+
+        result = helper.render_seo_meta_tags(test_page)
+        expect(result).not_to include('property="og:image"')
+        expect(result).not_to include('name="twitter:image"')
+        expect(Rails.logger).to have_received(:warn).with(/Failed to generate variant URL/).at_least(:once)
       end
     end
   end

--- a/spec/helpers/panda/cms/seo_helper_spec.rb
+++ b/spec/helpers/panda/cms/seo_helper_spec.rb
@@ -142,12 +142,15 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
 
     context "with og_image attached" do
       it "renders og:image tags with dimensions" do
-        # Mock the og_image attachment
+        # Mock the og_image attachment and variant processing chain
+        blob_double = double(signed_id: "signed_id", filename: "image.jpg")
+        variation_double = double(key: "variant_key")
+        processed_double = double(blob: blob_double, variation: variation_double)
+        variant_double = double(processed: processed_double)
+
         allow(test_page).to receive_message_chain(:og_image, :attached?).and_return(true)
-        allow(test_page).to receive_message_chain(:og_image, :variant).and_return(
-          double(url: "https://example.com/image.jpg")
-        )
-        allow(helper).to receive(:rails_representation_url).and_return("https://example.com/image.jpg")
+        allow(test_page).to receive_message_chain(:og_image, :variant).and_return(variant_double)
+        allow(helper).to receive(:rails_blob_representation_proxy_url).and_return("https://example.com/image.jpg")
 
         result = helper.render_seo_meta_tags(test_page)
         expect(result).to include('property="og:image"')


### PR DESCRIPTION
## Summary
- In Rails 8.1, `VariantWithRecord` no longer implements `to_model`, breaking `url_for(variant)` 
- `rails_representation_url` was renamed to `rails_blob_representation_proxy_url`
- Adds `variant_representation_url` private helper that uses the correct Rails 8.1 API
- Falls back gracefully if URL generation fails (logs warning, skips OG image tags)

## Root cause
Both `url_for(resource.og_image.variant(:og_share))` and `rails_representation_url(...)` raise `NoMethodError` on Rails 8.1:
- `url_for` → `undefined method 'to_model' for ActiveStorage::VariantWithRecord`
- `rails_representation_url` → `undefined method 'rails_representation_url'` (route renamed)

## Test plan
- [x] All 15 SEO helper specs pass
- [ ] Verify OG image meta tags render on staging for pages/posts with OG images
- [ ] Verify no 500 errors on pages with OG images

🤖 Generated with [Claude Code](https://claude.com/claude-code)