### PR TITLE
Fix ActiveStorage variant image previews in admin for Rails 8.1

### DIFF
--- a/app/views/panda/cms/admin/pages/edit.html.erb
+++ b/app/views/panda/cms/admin/pages/edit.html.erb
@@ -146,7 +146,7 @@
             } %>
             <% if page.og_image.attached? %>
               <div class="mt-2">
-                <%= image_tag page.og_image.variant(:og_share), class: "max-w-xs rounded-xl border border-gray-200" %>
+                <%= image_tag url_for(page.og_image.variant(:og_share)), class: "max-w-xs rounded-xl border border-gray-200" %>
               </div>
             <% end %>
           </div>

--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -94,7 +94,7 @@
         } %>
         <% if f.object.present? && f.object.persisted? && f.object.og_image.attached? %>
           <div class="mt-2">
-            <%= image_tag f.object.og_image.variant(:og_share), class: "max-w-xs rounded border border-gray-300" %>
+            <%= image_tag url_for(f.object.og_image.variant(:og_share)), class: "max-w-xs rounded border border-gray-300" %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Summary
- Fixes `ActionView::Template::Error` (undefined method `to_model` for `ActiveStorage::VariantWithRecord`) when editing posts/pages with OG images in the admin
- Wraps `image_tag` variant arguments in `url_for()` to explicitly resolve URLs before rendering
- Follow-up to #325 which fixed the same issue in the SEO helper but missed the admin view previews

## Files changed
- `app/views/panda/cms/admin/posts/_form.html.erb` — OG image preview on post edit
- `app/views/panda/cms/admin/pages/edit.html.erb` — OG image preview on page edit

## Root cause
Rails 8.1's `ActionView::Helpers::AssetTagHelper#resolve_asset_source` tries to call `to_model` on the argument to `image_tag`. `ActiveStorage::VariantWithRecord` doesn't implement `to_model`, causing a `NoMethodError`. Wrapping in `url_for()` resolves the variant to a plain URL string first — compatible with Rails 7.0+.

## Test plan
- [x] All pre-commit hooks pass (Brakeman, bundle-audit, erblint, standardrb, zeitwerk)
- [x] No regressions in panda-cms specs (21 pre-existing failures unrelated to this change)
- [ ] Verify OG image preview renders on post edit in production
- [ ] Verify OG image preview renders on page edit in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)