### PR TITLE
Report missing block data in form components via Rails.error

### DIFF
--- a/app/components/panda/cms/form_component.rb
+++ b/app/components/panda/cms/form_component.rb
@@ -31,6 +31,7 @@ module Panda
 
         block = find_block
         if block.nil?
+          report_missing_data("Block not found (kind: #{KIND}, key: #{@key}, template: #{Current.page&.panda_cms_template_id})")
           @editable_state = false
           return
         end
@@ -40,6 +41,12 @@ module Panda
         @block_content_id = @block_content_obj&.id
         @form = Panda::CMS::Form.find_by(id: @form_id) if @form_id
         @available_forms = Panda::CMS::Form.includes(:form_fields).order(:name) if @editable_state
+
+        unless @editable_state
+          report_missing_data("BlockContent missing for block #{block.id} on page #{Current.page&.id}") unless @block_content_obj
+          report_missing_data("BlockContent has no form ID (content: #{@block_content_obj&.content.inspect})") if @block_content_obj && @form_id.blank?
+          report_missing_data("Form not found for ID #{@form_id}") if @form_id.present? && @form.nil?
+        end
       end
 
       def find_block
@@ -74,6 +81,20 @@ module Panda
         url_param_valid = embed_id.present? && embed_id == page_id
 
         session_valid || url_param_valid
+      end
+
+      def report_missing_data(detail)
+        return if @editable_state
+
+        message = "[FormComponent] #{detail} (page: #{Current.page&.path})"
+        error = Panda::CMS::MissingBlockDataError.new(message)
+        Rails.error.report(error, handled: true, severity: :error, context: {
+          component: self.class.name,
+          key: @key,
+          page_path: Current.page&.path,
+          page_id: Current.page&.id,
+          template_id: Current.page&.panda_cms_template_id
+        })
       end
 
       public

--- a/app/components/panda/cms/helpdesk_form_component.rb
+++ b/app/components/panda/cms/helpdesk_form_component.rb
@@ -43,6 +43,7 @@ module Panda
 
         block = find_block
         if block.nil?
+          report_missing_data("Block not found (kind: #{KIND}, key: #{@key}, template: #{Current.page&.panda_cms_template_id})")
           @editable_state = false
           return
         end
@@ -52,7 +53,13 @@ module Panda
         @block_content_id = @block_content_obj&.id
         @department = Panda::Helpdesk::Department.find_by(id: @department_id) if @department_id
         @available_departments = Panda::Helpdesk::Department.active.order(:name) if @editable_state
-        @current_user = resolve_current_user unless @editable_state
+
+        unless @editable_state
+          report_missing_data("BlockContent missing for block #{block.id} on page #{Current.page&.id}") unless @block_content_obj
+          report_missing_data("BlockContent has no department ID (content: #{@block_content_obj&.content.inspect})") if @block_content_obj && @department_id.blank?
+          report_missing_data("Department not found for ID #{@department_id}") if @department_id.present? && @department.nil?
+          @current_user = resolve_current_user
+        end
       end
 
       def find_block
@@ -97,6 +104,20 @@ module Panda
       rescue => e
         Rails.logger.error("[HelpdeskFormComponent] Failed to resolve current user: #{e.class}: #{e.message}")
         nil
+      end
+
+      def report_missing_data(detail)
+        return if @editable_state
+
+        message = "[HelpdeskFormComponent] #{detail} (page: #{Current.page&.path})"
+        error = Panda::CMS::MissingBlockDataError.new(message)
+        Rails.error.report(error, handled: true, severity: :error, context: {
+          component: self.class.name,
+          key: @key,
+          page_path: Current.page&.path,
+          page_id: Current.page&.id,
+          template_id: Current.page&.panda_cms_template_id
+        })
       end
     end
   end

--- a/lib/panda/cms/engine.rb
+++ b/lib/panda/cms/engine.rb
@@ -89,6 +89,7 @@ module Panda
     end
 
     class MissingBlockError < StandardError; end
+    class MissingBlockDataError < StandardError; end
     class BlockError < StandardError; end
   end
 end


### PR DESCRIPTION
## Summary

- `HelpdeskFormComponent` and `FormComponent` silently rendered nothing when block data was missing — making misconfiguration invisible
- Now both components call `Rails.error.report()` with detailed context when data is missing in non-edit mode
- Errors flow to AppSignal (or any error subscriber) while the page continues to render normally
- Add `MissingBlockDataError` error class

## What gets reported

Each report includes component name, key, page path, page ID, and template ID. Specific cases:

- **Block not found** — wrong kind, key, or template mismatch
- **BlockContent missing** — block exists but no content for this page
- **No form/department ID** — block content exists but is empty
- **Form/department not found** — ID stored but record doesn't exist

## Test plan

- [x] All 19 component specs pass (helpdesk_form + form)
- [x] All pre-commit hooks pass (brakeman, standardrb, erblint, zeitwerk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)