### PR TITLE
Fix CI: update tests for 5-item menu fixtures

### DIFF
--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -160,8 +160,8 @@ module Panda
         return seo_title if seo_title.present?
         return title unless inherit_seo
 
-        # Traverse up tree to find nearest ancestor with a value
-        self_and_ancestors.to_a.reverse.find { |p| p.seo_title.present? }&.seo_title || title
+        # Traverse up tree to find inherited value
+        self_and_ancestors.to_a.rfind { |p| p.seo_title.present? }&.seo_title || title
       end
 
       #
@@ -175,7 +175,7 @@ module Panda
         return seo_description if seo_description.present?
         return nil unless inherit_seo
 
-        self_and_ancestors.to_a.reverse.find { |p| p.seo_description.present? }&.seo_description
+        self_and_ancestors.to_a.rfind { |p| p.seo_description.present? }&.seo_description
       end
 
       #

--- a/app/models/panda/cms/page.rb
+++ b/app/models/panda/cms/page.rb
@@ -160,8 +160,8 @@ module Panda
         return seo_title if seo_title.present?
         return title unless inherit_seo
 
-        # Traverse up tree to find inherited value
-        self_and_ancestors.to_a.rfind { |p| p.seo_title.present? }&.seo_title || title
+        # Traverse up tree to find nearest ancestor with a value
+        self_and_ancestors.to_a.reverse.find { |p| p.seo_title.present? }&.seo_title || title
       end
 
       #
@@ -175,7 +175,7 @@ module Panda
         return seo_description if seo_description.present?
         return nil unless inherit_seo
 
-        self_and_ancestors.to_a.rfind { |p| p.seo_description.present? }&.seo_description
+        self_and_ancestors.to_a.reverse.find { |p| p.seo_description.present? }&.seo_description
       end
 
       #

--- a/lib/panda/cms/bulk_editor.rb
+++ b/lib/panda/cms/bulk_editor.rb
@@ -330,7 +330,7 @@ module Panda
 
         # Pages — populate metadata for every page so pages without
         # block_contents are still fully represented in the export.
-        Panda::CMS::Page.includes(:template).order("lft ASC").each do |page|
+        Panda::CMS::Page.includes(:template, :parent, og_image_attachment: :blob).order("lft ASC").each do |page|
           item = data["pages"][page.path] ||= {}
           item["id"] = page.id
           item["path"] = page.path

--- a/lib/panda/cms/bulk_editor.rb
+++ b/lib/panda/cms/bulk_editor.rb
@@ -328,9 +328,30 @@ module Panda
           "settings" => {}
         }
 
-        # Pages
+        # Pages — populate metadata for every page so pages without
+        # block_contents are still fully represented in the export.
         Panda::CMS::Page.includes(:template).order("lft ASC").each do |page|
-          data["pages"][page.path] ||= {}
+          item = data["pages"][page.path] ||= {}
+          item["id"] = page.id
+          item["path"] = page.path
+          item["title"] = page.title
+          item["template"] = page.template.name
+          item["parent"] = page.parent&.path
+          item["status"] = page.status
+          item["page_type"] = page.page_type
+          item["seo_title"] = page.seo_title if page.seo_title.present?
+          item["seo_description"] = page.seo_description if page.seo_description.present?
+          item["seo_keywords"] = page.seo_keywords if page.seo_keywords.present?
+          item["seo_index_mode"] = page.seo_index_mode
+          item["canonical_url"] = page.canonical_url if page.canonical_url.present?
+          item["og_type"] = page.og_type
+          item["og_title"] = page.og_title if page.og_title.present?
+          item["og_description"] = page.og_description if page.og_description.present?
+          item["og_image_url"] = active_storage_url(page.og_image) if page.og_image.attached?
+          item["contributor_count"] = page.contributor_count if page.respond_to?(:contributor_count)
+          item["workflow_status"] = page.workflow_status if page.respond_to?(:workflow_status)
+          item["inherit_seo"] = page.inherit_seo if page.respond_to?(:inherit_seo)
+          item["contents"] ||= {}
         end
 
         # TODO: Eventually set the position of the block in the template, and then order from there rather than the name?

--- a/lib/panda/cms/sanctuary_demo.rb
+++ b/lib/panda/cms/sanctuary_demo.rb
@@ -302,7 +302,7 @@ module Panda
 
         @pages[:donate] = create_page(
           path: "/donate",
-          title: "Donate",
+          title: "Make a Donation",
           template: @templates[:sanctuary_page],
           parent: @pages[:home],
           seo_description: "Support The Panda Sanctuary with a donation. Help us protect pandas for future generations."

--- a/spec/models/panda/cms/menu_spec.rb
+++ b/spec/models/panda/cms/menu_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Panda::CMS::Menu, type: :model do
 
   describe "associations" do
     it "has many menu items ordered by lft" do
-      expect(static_menu.menu_items.count).to eq(3)
+      expect(static_menu.menu_items.count).to eq(5)
       expect(static_menu.menu_items.first).to eq(panda_cms_menu_items(:home_link))
     end
 
@@ -445,12 +445,12 @@ RSpec.describe Panda::CMS::Menu, type: :model do
 
     context "alphabetical ordering" do
       it "sorts menu items alphabetically by text" do
-        # Main menu items: Home(lft:1), About(lft:3), Services(lft:5)
+        # Main menu items: Home(lft:1), About(lft:3), Services(lft:5), Support Us(lft:7), Donate(lft:9)
         static_menu.update_column(:ordering, "alphabetical")
         static_menu.apply_ordering_to_static_items!
 
         ordered = static_menu.menu_items.reload.order(:lft).pluck(:text)
-        expect(ordered).to eq(["About", "Home", "Services"])
+        expect(ordered).to eq(["About", "Donate", "Home", "Services", "Support Us"])
       end
     end
 
@@ -460,19 +460,19 @@ RSpec.describe Panda::CMS::Menu, type: :model do
         static_menu.apply_ordering_to_static_items!
 
         ordered = static_menu.menu_items.reload.order(:lft).pluck(:text)
-        expect(ordered).to eq(["Services", "Home", "About"])
+        expect(ordered).to eq(["Support Us", "Services", "Home", "Donate", "About"])
       end
     end
 
     context "page_order ordering" do
       it "sorts menu items by their page's lft position" do
-        # Pages: Homepage(lft:1), About(lft:2), Services(lft:6)
-        # Menu items: Home->Homepage, About->About page, Services->Services page
+        # Pages: Homepage(lft:1), About(lft:2), Services(lft:6), Support Us(lft:8), Donate(lft:9)
+        # Menu items: Home->Homepage, About->About page, Services->Services page, Support Us->Support page, Donate->Donate page
         static_menu.update_column(:ordering, "page_order")
         static_menu.apply_ordering_to_static_items!
 
         ordered = static_menu.menu_items.reload.order(:lft).pluck(:text)
-        expect(ordered).to eq(["Home", "About", "Services"])
+        expect(ordered).to eq(["Home", "About", "Services", "Support Us", "Donate"])
       end
     end
 
@@ -497,7 +497,7 @@ RSpec.describe Panda::CMS::Menu, type: :model do
     end
 
     it "has associated menu items" do
-      expect(static_menu.menu_items.count).to eq(3)
+      expect(static_menu.menu_items.count).to eq(5)
       expect(panda_cms_menu_items(:home_link).menu).to eq(static_menu)
     end
   end

--- a/spec/requests/panda/cms/admin/menus_controller_spec.rb
+++ b/spec/requests/panda/cms/admin/menus_controller_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
   let(:home_item) { panda_cms_menu_items(:home_link) }
   let(:about_item) { panda_cms_menu_items(:about_link) }
   let(:services_item) { panda_cms_menu_items(:services_link) }
+  let(:support_item) { panda_cms_menu_items(:support_link) }
+  let(:donate_item) { panda_cms_menu_items(:donate_link) }
 
   before do
     post "/admin/test_sessions", params: {user_id: admin_user.id}
@@ -17,8 +19,8 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
 
   describe "PATCH /admin/cms/menus/:id - reordering" do
     it "reorders existing menu items based on position params" do
-      # Original order: Home(lft:1), About(lft:3), Services(lft:5)
-      # Desired order: Services, Home, About
+      # Original order: Home(lft:1), About(lft:3), Services(lft:5), Support Us(lft:7), Donate(lft:9)
+      # Desired order: Services, Home, About, Support Us, Donate
       patch "/admin/cms/menus/#{main_menu.id}", params: {
         menu: {
           name: main_menu.name,
@@ -26,7 +28,9 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
           menu_items_attributes: {
             "0" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "0"},
             "1" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "1"},
-            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "2"}
+            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "2"},
+            "3" => {id: support_item.id, text: "Support Us", panda_cms_page_id: support_item.panda_cms_page_id, position: "3"},
+            "4" => {id: donate_item.id, text: "Donate", panda_cms_page_id: donate_item.panda_cms_page_id, position: "4"}
           }
         }
       }
@@ -34,11 +38,11 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
       expect(response).to redirect_to("/admin/cms/menus")
 
       reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
-      expect(reordered).to eq(["Services", "Home", "About"])
+      expect(reordered).to eq(["Services", "Home", "About", "Support Us", "Donate"])
     end
 
     it "preserves order when positions match current order" do
-      # Submit in the same order as current: Home, About, Services
+      # Submit in the same order as current: Home, About, Services, Support Us, Donate
       patch "/admin/cms/menus/#{main_menu.id}", params: {
         menu: {
           name: main_menu.name,
@@ -46,7 +50,9 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
           menu_items_attributes: {
             "0" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "0"},
             "1" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "1"},
-            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"}
+            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"},
+            "3" => {id: support_item.id, text: "Support Us", panda_cms_page_id: support_item.panda_cms_page_id, position: "3"},
+            "4" => {id: donate_item.id, text: "Donate", panda_cms_page_id: donate_item.panda_cms_page_id, position: "4"}
           }
         }
       }
@@ -54,11 +60,11 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
       expect(response).to redirect_to("/admin/cms/menus")
 
       reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
-      expect(reordered).to eq(["Home", "About", "Services"])
+      expect(reordered).to eq(["Home", "About", "Services", "Support Us", "Donate"])
     end
 
     it "handles reorder with a destroyed item" do
-      # Destroy About, reorder: Services, Home
+      # Destroy About, reorder: Services, Home, Support Us, Donate
       patch "/admin/cms/menus/#{main_menu.id}", params: {
         menu: {
           name: main_menu.name,
@@ -66,7 +72,9 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
           menu_items_attributes: {
             "0" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "0"},
             "1" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "1"},
-            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, _destroy: "1"}
+            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, _destroy: "1"},
+            "3" => {id: support_item.id, text: "Support Us", panda_cms_page_id: support_item.panda_cms_page_id, position: "2"},
+            "4" => {id: donate_item.id, text: "Donate", panda_cms_page_id: donate_item.panda_cms_page_id, position: "3"}
           }
         }
       }
@@ -74,7 +82,7 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
       expect(response).to redirect_to("/admin/cms/menus")
 
       reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
-      expect(reordered).to eq(["Services", "Home"])
+      expect(reordered).to eq(["Services", "Home", "Support Us", "Donate"])
     end
 
     it "skips reorder when no position params are present" do
@@ -92,13 +100,13 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
       expect(response).to redirect_to("/admin/cms/menus")
 
       reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
-      expect(reordered).to eq(["Home", "About", "Services"])
+      expect(reordered).to eq(["Home", "About", "Services", "Support Us", "Donate"])
     end
   end
 
   describe "PATCH /admin/cms/menus/:id - ordering change" do
     it "applies alphabetical ordering to static menu items" do
-      # Original order: Home, About, Services
+      # Original order: Home, About, Services, Support Us, Donate
       patch "/admin/cms/menus/#{main_menu.id}", params: {
         menu: {
           name: main_menu.name,
@@ -107,7 +115,9 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
           menu_items_attributes: {
             "0" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "0"},
             "1" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "1"},
-            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"}
+            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"},
+            "3" => {id: support_item.id, text: "Support Us", panda_cms_page_id: support_item.panda_cms_page_id, position: "3"},
+            "4" => {id: donate_item.id, text: "Donate", panda_cms_page_id: donate_item.panda_cms_page_id, position: "4"}
           }
         }
       }
@@ -115,7 +125,7 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
       expect(response).to redirect_to("/admin/cms/menus")
 
       reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
-      expect(reordered).to eq(["About", "Home", "Services"])
+      expect(reordered).to eq(["About", "Donate", "Home", "Services", "Support Us"])
     end
 
     it "applies reverse alphabetical ordering to static menu items" do
@@ -127,7 +137,9 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
           menu_items_attributes: {
             "0" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "0"},
             "1" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "1"},
-            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"}
+            "2" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "2"},
+            "3" => {id: support_item.id, text: "Support Us", panda_cms_page_id: support_item.panda_cms_page_id, position: "3"},
+            "4" => {id: donate_item.id, text: "Donate", panda_cms_page_id: donate_item.panda_cms_page_id, position: "4"}
           }
         }
       }
@@ -135,11 +147,11 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
       expect(response).to redirect_to("/admin/cms/menus")
 
       reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
-      expect(reordered).to eq(["Services", "Home", "About"])
+      expect(reordered).to eq(["Support Us", "Services", "Home", "Donate", "About"])
     end
 
     it "uses manual reordering when ordering is default" do
-      # Submit with positions reordered: Services, Home, About
+      # Submit with positions reordered: Services, Home, About, Support Us, Donate
       patch "/admin/cms/menus/#{main_menu.id}", params: {
         menu: {
           name: main_menu.name,
@@ -148,7 +160,9 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
           menu_items_attributes: {
             "0" => {id: services_item.id, text: "Services", panda_cms_page_id: services_item.panda_cms_page_id, position: "0"},
             "1" => {id: home_item.id, text: "Home", panda_cms_page_id: home_item.panda_cms_page_id, position: "1"},
-            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "2"}
+            "2" => {id: about_item.id, text: "About", panda_cms_page_id: about_item.panda_cms_page_id, position: "2"},
+            "3" => {id: support_item.id, text: "Support Us", panda_cms_page_id: support_item.panda_cms_page_id, position: "3"},
+            "4" => {id: donate_item.id, text: "Donate", panda_cms_page_id: donate_item.panda_cms_page_id, position: "4"}
           }
         }
       }
@@ -156,7 +170,7 @@ RSpec.describe "Admin Menus - Reordering", type: :request do
       expect(response).to redirect_to("/admin/cms/menus")
 
       reordered = main_menu.menu_items.reload.order(:lft).pluck(:text)
-      expect(reordered).to eq(["Services", "Home", "About"])
+      expect(reordered).to eq(["Services", "Home", "About", "Support Us", "Donate"])
     end
   end
 


### PR DESCRIPTION
## Summary

- Update menu model and controller specs for 5-item main_menu fixtures (added in #327 but tests not updated)
- Rename SanctuaryDemo donate page to "Make a Donation" to avoid MenuItem text uniqueness collision with fixture's `/support-us/donate`
- Replace `Array#rfind` with `.reverse.find` for Ruby 3.4 compatibility (rfind is Ruby 4.0+)
- Fix BulkEditor export to populate page metadata for pages without block_contents (previously exported as empty hashes, causing "Title can't be blank" on reimport)

## Test plan

- [x] All 3 previously failing spec files pass (menu_spec, menus_controller_spec, sanctuary_demo_spec)
- [x] All 8 additional local failures fixed (page_spec SEO, bulk_editor_spec, seo_helper_spec)
- [x] Full test suite: 1082 examples, 0 non-flaky failures
- [x] StandardRB, Brakeman, ERB Lint, Zeitwerk all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)