### PR TITLE
Report missing block data in form components via Rails.error

### DIFF
--- a/app/components/panda/cms/concerns/block_data_reporting.rb
+++ b/app/components/panda/cms/concerns/block_data_reporting.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Panda
+  module CMS
+    module Concerns
+      # Shared error reporting for components that depend on Block/BlockContent data.
+      # Reports to Rails.error (AppSignal, Sentry, etc.) without raising — the page
+      # continues to render but ops gets an alert about misconfigured CMS data.
+      module BlockDataReporting
+        private
+
+        def report_missing_data(detail)
+          return if @editable_state
+
+          component_name = self.class.name.demodulize
+          message = "[#{component_name}] #{detail} (page: #{Current.page&.path})"
+          error = Panda::CMS::MissingBlockDataError.new(message)
+          Rails.error.report(error, handled: true, severity: :error, context: {
+            component: self.class.name,
+            key: @key,
+            page_path: Current.page&.path,
+            page_id: Current.page&.id,
+            template_id: Current.page&.panda_cms_template_id
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/components/panda/cms/concerns/block_data_reporting.rb
+++ b/app/components/panda/cms/concerns/block_data_reporting.rb
@@ -9,6 +9,15 @@ module Panda
       module BlockDataReporting
         private
 
+        # Normalize block content IDs: treat "{}" (the JSONB empty-object default
+        # stored by the inline selector when nothing is selected) as nil.
+        def normalize_block_content_id(raw)
+          value = raw.to_s.strip
+          return nil if value.blank? || value == "{}"
+          return nil unless value.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i)
+          value
+        end
+
         def report_missing_data(detail)
           return if @editable_state
 

--- a/app/components/panda/cms/form_component.rb
+++ b/app/components/panda/cms/form_component.rb
@@ -39,7 +39,7 @@ module Panda
         end
 
         @block_content_obj = find_block_content(block)
-        @form_id = @block_content_obj&.content.to_s.presence
+        @form_id = normalize_block_content_id(@block_content_obj&.content)
         @block_content_id = @block_content_obj&.id
         @form = Panda::CMS::Form.find_by(id: @form_id) if @form_id
         @available_forms = Panda::CMS::Form.includes(:form_fields).order(:name) if @editable_state

--- a/app/components/panda/cms/form_component.rb
+++ b/app/components/panda/cms/form_component.rb
@@ -7,6 +7,8 @@ module Panda
     # @param key [Symbol] The key to use for the form component
     # @param editable [Boolean] If the form is editable or not (defaults to true)
     class FormComponent < Panda::Core::Base
+      include Concerns::BlockDataReporting
+
       KIND = "form"
 
       attr_reader :key, :editable
@@ -31,6 +33,7 @@ module Panda
 
         block = find_block
         if block.nil?
+          report_missing_data("Block not found (kind: #{KIND}, key: #{@key}, template: #{Current.page&.panda_cms_template_id})")
           @editable_state = false
           return
         end
@@ -40,6 +43,12 @@ module Panda
         @block_content_id = @block_content_obj&.id
         @form = Panda::CMS::Form.find_by(id: @form_id) if @form_id
         @available_forms = Panda::CMS::Form.includes(:form_fields).order(:name) if @editable_state
+
+        unless @editable_state
+          report_missing_data("BlockContent missing for block #{block.id} on page #{Current.page&.id}") unless @block_content_obj
+          report_missing_data("BlockContent has no form ID (content: #{@block_content_obj&.content.inspect})") if @block_content_obj && @form_id.blank?
+          report_missing_data("Form not found for ID #{@form_id}") if @form_id.present? && @form.nil?
+        end
       end
 
       def find_block

--- a/app/components/panda/cms/helpdesk_form_component.rb
+++ b/app/components/panda/cms/helpdesk_form_component.rb
@@ -10,6 +10,8 @@ module Panda
     # @param sign_in_message [String, nil] Custom HTML sign-in message for unauthenticated users
     # @param return_to [String, nil] URL to redirect to after form submission
     class HelpdeskFormComponent < Panda::Core::Base
+      include Concerns::BlockDataReporting
+
       KIND = "helpdesk_form"
 
       attr_reader :key, :editable, :sign_in_message, :return_to
@@ -43,6 +45,7 @@ module Panda
 
         block = find_block
         if block.nil?
+          report_missing_data("Block not found (kind: #{KIND}, key: #{@key}, template: #{Current.page&.panda_cms_template_id})")
           @editable_state = false
           return
         end
@@ -52,7 +55,12 @@ module Panda
         @block_content_id = @block_content_obj&.id
         @department = Panda::Helpdesk::Department.find_by(id: @department_id) if @department_id
         @available_departments = Panda::Helpdesk::Department.active.order(:name) if @editable_state
-        @current_user = resolve_current_user unless @editable_state
+        unless @editable_state
+          report_missing_data("BlockContent missing for block #{block.id} on page #{Current.page&.id}") unless @block_content_obj
+          report_missing_data("BlockContent has no department ID (content: #{@block_content_obj&.content.inspect})") if @block_content_obj && @department_id.blank?
+          report_missing_data("Department not found for ID #{@department_id}") if @department_id.present? && @department.nil?
+          @current_user = resolve_current_user
+        end
       end
 
       def find_block

--- a/app/components/panda/cms/helpdesk_form_component.rb
+++ b/app/components/panda/cms/helpdesk_form_component.rb
@@ -51,7 +51,7 @@ module Panda
         end
 
         @block_content_obj = find_block_content(block)
-        @department_id = @block_content_obj&.content.to_s.presence
+        @department_id = normalize_block_content_id(@block_content_obj&.content)
         @block_content_id = @block_content_obj&.id
         @department = Panda::Helpdesk::Department.find_by(id: @department_id) if @department_id
         @available_departments = Panda::Helpdesk::Department.active.order(:name) if @editable_state

--- a/lib/panda/cms/engine.rb
+++ b/lib/panda/cms/engine.rb
@@ -89,6 +89,7 @@ module Panda
     end
 
     class MissingBlockError < StandardError; end
+    class MissingBlockDataError < StandardError; end
     class BlockError < StandardError; end
   end
 end

--- a/spec/components/panda/cms/form_component_spec.rb
+++ b/spec/components/panda/cms/form_component_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe Panda::CMS::FormComponent, type: :component do
         expect(output.text.strip).to eq("")
       end
 
-it "reports missing form ID to Rails.error" do
-  expect(Rails.error).to receive(:report).with(
-    an_instance_of(Panda::CMS::MissingBlockDataError),
-    hash_including(handled: true, severity: :error)
-  )
-  render_inline(described_class.new(key: :contact_form, editable: false))
-end
+      it "reports missing form ID to Rails.error" do
+        expect(Rails.error).to receive(:report).with(
+          an_instance_of(Panda::CMS::MissingBlockDataError),
+          hash_including(handled: true, severity: :error)
+        )
+        render_inline(described_class.new(key: :contact_form, editable: false))
+      end
     end
 
     context "when the referenced form has been deleted (stale ID)" do
@@ -92,13 +92,13 @@ end
         expect(output.text.strip).to eq("")
       end
 
-it "reports missing form to Rails.error" do
-  expect(Rails.error).to receive(:report).with(
-    an_instance_of(Panda::CMS::MissingBlockDataError),
-    hash_including(handled: true, severity: :error)
-  )
-  render_inline(described_class.new(key: :contact_form, editable: false))
-end
+      it "reports missing form to Rails.error" do
+        expect(Rails.error).to receive(:report).with(
+          an_instance_of(Panda::CMS::MissingBlockDataError),
+          hash_including(handled: true, severity: :error)
+        )
+        render_inline(described_class.new(key: :contact_form, editable: false))
+      end
     end
 
     context "when the form is not accepting submissions" do
@@ -122,13 +122,13 @@ end
         expect(output.text.strip).to eq("")
       end
 
-it "reports missing block data to Rails.error" do
-  expect(Rails.error).to receive(:report).with(
-    an_instance_of(Panda::CMS::MissingBlockDataError),
-    hash_including(handled: true, severity: :error, context: hash_including(:component, :key, :page_path))
-  )
-  render_inline(described_class.new(key: :nonexistent_form, editable: false))
-end
+      it "reports missing block data to Rails.error" do
+        expect(Rails.error).to receive(:report).with(
+          an_instance_of(Panda::CMS::MissingBlockDataError),
+          hash_including(handled: true, severity: :error, context: hash_including(:component, :key, :page_path))
+        )
+        render_inline(described_class.new(key: :nonexistent_form, editable: false))
+      end
     end
   end
 end

--- a/spec/components/panda/cms/form_component_spec.rb
+++ b/spec/components/panda/cms/form_component_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe Panda::CMS::FormComponent, type: :component do
         expect(output.css("form")).to be_empty
         expect(output.text.strip).to eq("")
       end
+
+it "reports missing form ID to Rails.error" do
+  expect(Rails.error).to receive(:report).with(
+    an_instance_of(Panda::CMS::MissingBlockDataError),
+    hash_including(handled: true, severity: :error)
+  )
+  render_inline(described_class.new(key: :contact_form, editable: false))
+end
     end
 
     context "when the referenced form has been deleted (stale ID)" do
@@ -83,6 +91,14 @@ RSpec.describe Panda::CMS::FormComponent, type: :component do
         expect(output.css("form")).to be_empty
         expect(output.text.strip).to eq("")
       end
+
+it "reports missing form to Rails.error" do
+  expect(Rails.error).to receive(:report).with(
+    an_instance_of(Panda::CMS::MissingBlockDataError),
+    hash_including(handled: true, severity: :error)
+  )
+  render_inline(described_class.new(key: :contact_form, editable: false))
+end
     end
 
     context "when the form is not accepting submissions" do
@@ -105,6 +121,14 @@ RSpec.describe Panda::CMS::FormComponent, type: :component do
         expect(output.css("form")).to be_empty
         expect(output.text.strip).to eq("")
       end
+
+it "reports missing block data to Rails.error" do
+  expect(Rails.error).to receive(:report).with(
+    an_instance_of(Panda::CMS::MissingBlockDataError),
+    hash_including(handled: true, severity: :error, context: hash_including(:component, :key, :page_path))
+  )
+  render_inline(described_class.new(key: :nonexistent_form, editable: false))
+end
     end
   end
 end


### PR DESCRIPTION
## Summary

- `HelpdeskFormComponent` and `FormComponent` silently rendered nothing when block data was missing — making misconfiguration invisible
- Now both components call `Rails.error.report()` with detailed context when data is missing in non-edit mode
- Errors flow to AppSignal (or any error subscriber) while the page continues to render normally

## Changes

- **`BlockDataReporting` concern** — shared error reporting extracted to avoid duplication between components
- **`MissingBlockDataError`** — new error class for these reports
- **Specs** — verify `Rails.error.report` is called for missing block, empty content, and stale IDs

## What gets reported

Each report includes component name, key, page path, page ID, and template ID:
- Block not found (wrong kind/key/template)
- BlockContent missing (block exists but no content for page)
- No form/department ID (content is empty)
- Form/department not found (stale ID)

## Test plan

- [x] All 22 component specs pass (13 form + 9 helpdesk_form)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)