### PR TITLE
Read pre-computed footnotes from structured cached_content

### DIFF
--- a/app/components/panda/cms/code_component.rb
+++ b/app/components/panda/cms/code_component.rb
@@ -39,7 +39,12 @@ module Panda
         content = @block_content_obj&.content
         # If content is EditorJS data (Hash), use the pre-rendered cached_content instead
         @code_content = if content.is_a?(Hash)
-          @block_content_obj&.cached_content.to_s
+          cached = @block_content_obj&.cached_content
+          if cached.is_a?(Hash) && cached.key?("html")
+            cached["html"].to_s
+          else
+            cached.to_s
+          end
         else
           content.to_s
         end

--- a/app/components/panda/cms/rich_text_component.rb
+++ b/app/components/panda/cms/rich_text_component.rb
@@ -96,14 +96,32 @@ module Panda
         end
 
         @block_content_id = @block_content.id
-        # For editing, use content (EditorJS JSON) directly
-        # For display, prefer cached_content (pre-rendered HTML) for speed
-        raw_content = if @editable_state
-          @block_content.content
+
+        if @editable_state
+          # For editing, use raw EditorJS JSON
+          @content = @block_content.content.presence || empty_editor_js_content
+          @precomputed_footnotes = nil
         else
-          @block_content.cached_content || @block_content.content
+          load_display_content
         end
-        @content = raw_content.presence || empty_editor_js_content
+      end
+
+      def load_display_content
+        cached = @block_content.cached_content
+
+        if cached.is_a?(Hash) && cached.key?("html")
+          # New structured format: pre-rendered HTML + pre-computed footnotes
+          @content = cached["html"].presence || "<p></p>"
+          @precomputed_footnotes = cached["footnotes"]&.map(&:symbolize_keys)
+        elsif cached.present?
+          # Legacy format: plain HTML string in cached_content
+          @content = cached
+          @precomputed_footnotes = nil
+        else
+          # No cached content, fall back to raw EditorJS JSON
+          @content = @block_content.content.presence || empty_editor_js_content
+          @precomputed_footnotes = nil
+        end
       end
 
       def prepare_content
@@ -129,12 +147,19 @@ module Panda
       end
 
       def prepare_display_content
-        @rendered_content = if @content.blank? || @content == "{}"
-          "<p></p>"
+        if @precomputed_footnotes
+          # Content is pre-rendered HTML from cached_content, footnotes are pre-computed
+          @rendered_content = @content.presence || "<p></p>"
+          @footnotes = @precomputed_footnotes.presence
         else
-          render_content_for_display(@content)
+          # Legacy path: render from EditorJS JSON and extract footnotes
+          @rendered_content = if @content.blank? || @content == "{}"
+            "<p></p>"
+          else
+            render_content_for_display(@content)
+          end
+          @footnotes = extract_footnotes_from_content
         end
-        @footnotes = extract_footnotes_from_content
       rescue => e
         Rails.logger.error("RichTextComponent render error: #{e.message}\nContent: #{@content.inspect}")
         @rendered_content = "<p></p>"

--- a/spec/components/panda/cms/code_component_spec.rb
+++ b/spec/components/panda/cms/code_component_spec.rb
@@ -76,5 +76,29 @@ RSpec.describe Panda::CMS::CodeComponent, type: :component do
         expect(output.to_html).not_to include("blocks")
       end
     end
+
+    context "when cached_content is structured Hash format" do
+      before do
+        editorjs_json = {
+          "time" => 1773316550000,
+          "blocks" => [
+            {"data" => {"text" => "Structured content"}, "type" => "paragraph"}
+          ],
+          "version" => "2.28.2"
+        }.to_json
+
+        @block_content.update_columns(
+          content: editorjs_json,
+          cached_content: {"html" => "<p>Structured content</p>", "footnotes" => []}
+        )
+      end
+
+      it "extracts HTML from structured cached_content" do
+        component = described_class.new(key: :test_code, editable: false)
+        output = render_inline(component)
+        expect(output.to_html).to include("<p>Structured content</p>")
+        expect(output.to_html).not_to include("footnotes")
+      end
+    end
   end
 end

--- a/spec/components/panda/cms/rich_text_component_spec.rb
+++ b/spec/components/panda/cms/rich_text_component_spec.rb
@@ -309,6 +309,82 @@ RSpec.describe Panda::CMS::RichTextComponent, type: :component do
     end
   end
 
+  describe "#load_display_content with structured cached_content" do
+    let(:component) { described_class.new(key: :test_content, editable: false) }
+    let(:test_block) do
+      Panda::CMS::Block.find_or_create_by!(
+        kind: "rich_text",
+        key: :test_content,
+        panda_cms_template_id: template.id
+      ) do |b|
+        b.name = "Test Content Block"
+      end
+    end
+
+    before do
+      @block_content = Panda::CMS::BlockContent.find_or_create_by!(
+        block: test_block,
+        page: page
+      )
+    end
+
+    after { @block_content&.destroy }
+
+    context "when cached_content is structured Hash with footnotes" do
+      before do
+        @block_content.update_columns(
+          content: {"blocks" => [{"type" => "paragraph", "data" => {"text" => "Test"}}], "version" => "2.28.2"},
+          cached_content: {
+            "html" => "<p>Pre-rendered content</p>",
+            "footnotes" => [
+              {"number" => 1, "id" => "fn-abc", "content" => "Source: example.com"}
+            ]
+          }
+        )
+      end
+
+      it "uses pre-rendered HTML without JSON parsing" do
+        output = render_inline(component)
+        expect(output.to_html).to include("Pre-rendered content")
+      end
+
+      it "renders pre-computed footnotes" do
+        output = render_inline(component)
+        expect(output.to_html).to include("Sources/References")
+        expect(output.to_html).to include("Source: example.com")
+      end
+    end
+
+    context "when cached_content is structured Hash without footnotes" do
+      before do
+        @block_content.update_columns(
+          content: {"blocks" => [{"type" => "paragraph", "data" => {"text" => "No footnotes"}}], "version" => "2.28.2"},
+          cached_content: {"html" => "<p>No footnotes here</p>", "footnotes" => []}
+        )
+      end
+
+      it "renders HTML without footnotes section" do
+        output = render_inline(component)
+        expect(output.to_html).to include("No footnotes here")
+        expect(output.to_html).not_to include("Sources/References")
+      end
+    end
+
+    context "when cached_content is legacy plain string" do
+      before do
+        @block_content.update_columns(
+          content: {"blocks" => [{"type" => "paragraph", "data" => {"text" => "Legacy"}}], "version" => "2.28.2"},
+          cached_content: "<p>Legacy cached HTML</p>"
+        )
+      end
+
+      it "falls back to rendering the string as HTML" do
+        output = render_inline(component)
+        expect(output.to_html).to include("Legacy cached HTML")
+      end
+    end
+  end
+
   describe "#render_content_for_display" do
     let(:component) { described_class.new }
 


### PR DESCRIPTION
## Summary
- RichTextComponent reads `cached_content["html"]` and `cached_content["footnotes"]` directly when available — zero JSON parsing on display
- Falls back to legacy rendering for plain-string `cached_content` (backward compatible)
- CodeComponent updated to extract HTML from the new structured format

## Motivation
Pairs with tastybamboo/panda-editor#XX. Together these changes eliminate all runtime JSON parsing for page display, reducing p95 response times by an estimated 100-500ms per page.

## Test plan
- [x] All 1085 panda-cms tests pass (862 unit + 223 system)
- [x] Legacy format tested via `update_columns` in code_component_spec
- [ ] Deploy alongside panda-editor change and re-generate cached_content

🤖 Generated with [Claude Code](https://claude.com/claude-code)