### PR TITLE
Fix Rails 8.1 ActiveStorage variant URL generation in admin views

### DIFF
--- a/app/views/panda/cms/admin/pages/edit.html.erb
+++ b/app/views/panda/cms/admin/pages/edit.html.erb
@@ -146,7 +146,7 @@
             } %>
             <% if page.og_image.attached? %>
               <div class="mt-2">
-                <%= image_tag url_for(page.og_image.variant(:og_share)), class: "max-w-xs rounded-xl border border-gray-200" %>
+                <%= image_tag variant_representation_url(page.og_image.variant(:og_share)), class: "max-w-xs rounded-xl border border-gray-200" %>
               </div>
             <% end %>
           </div>

--- a/app/views/panda/cms/admin/posts/_form.html.erb
+++ b/app/views/panda/cms/admin/posts/_form.html.erb
@@ -94,7 +94,7 @@
         } %>
         <% if f.object.present? && f.object.persisted? && f.object.og_image.attached? %>
           <div class="mt-2">
-            <%= image_tag url_for(f.object.og_image.variant(:og_share)), class: "max-w-xs rounded border border-gray-300" %>
+            <%= image_tag variant_representation_url(f.object.og_image.variant(:og_share)), class: "max-w-xs rounded border border-gray-300" %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Summary
- `url_for(variant)` fails in Rails 8.1 because `ActiveStorage::VariantWithRecord` no longer responds to `to_model`
- Replaces `url_for()` with the existing `variant_representation_url` helper in page edit and post form views
- The helper already handles both Rails 7.x and 8.1+ via `rails_blob_representation_proxy_url`

## Test plan
- [ ] Edit a page with an OG image attached — image preview should render without 500
- [ ] Edit a post with an OG image attached — image preview should render without 500
- [ ] Verify on both Rails 7.x and 8.1+ environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)