### PR TITLE
fix: Access ActiveStorage route helpers via url_helpers in Rails 8.1+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.3)
       drb (~> 2.0)
       prism (~> 1.5)
     multi_xml (0.8.1)
@@ -356,7 +356,7 @@ GEM
     puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/app/helpers/panda/cms/seo_helper.rb
+++ b/app/helpers/panda/cms/seo_helper.rb
@@ -68,13 +68,19 @@ module Panda
       # and rails_representation_url was renamed to rails_blob_representation_proxy_url.
       # Avoids eager processing — uses variant.blob and variant.variation directly so the
       # variant is only processed lazily when the representation URL is requested by a client.
+      #
+      # Note: ActiveStorage route helpers are not mixed into ActionView::Base in Rails 8.1+,
+      # so we access them via Rails.application.routes.url_helpers instead of respond_to?.
       def variant_representation_url(variant)
-        if respond_to?(:rails_blob_representation_proxy_url)
+        url_helpers = Rails.application.routes.url_helpers
+        if url_helpers.respond_to?(:rails_blob_representation_proxy_url)
           # Rails 8.1+
-          rails_blob_representation_proxy_url(
+          url_helpers.rails_blob_representation_proxy_url(
             variant.blob.signed_id,
             variant.variation.key,
-            variant.blob.filename
+            variant.blob.filename,
+            host: request.host_with_port,
+            protocol: request.protocol
           )
         else
           # Rails 7.x

--- a/spec/helpers/panda/cms/seo_helper_spec.rb
+++ b/spec/helpers/panda/cms/seo_helper_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
       end
 
       it "renders og:image tags with dimensions" do
-        allow(helper).to receive(:rails_blob_representation_proxy_url).and_return("https://example.com/image.jpg")
+        allow(Rails.application.routes.url_helpers).to receive(:rails_blob_representation_proxy_url).and_return("https://example.com/image.jpg")
 
         result = helper.render_seo_meta_tags(test_page)
         expect(result).to include('property="og:image"')
@@ -164,7 +164,7 @@ RSpec.describe Panda::CMS::SEOHelper, type: :helper do
       end
 
       it "gracefully skips image tags when URL generation fails" do
-        allow(helper).to receive(:rails_blob_representation_proxy_url)
+        allow(Rails.application.routes.url_helpers).to receive(:rails_blob_representation_proxy_url)
           .and_raise(ActionController::UrlGenerationError.new("missing keys"))
         allow(Rails.logger).to receive(:warn)
 


### PR DESCRIPTION
## Summary
- Fix `og:image` meta tags not rendering in Rails 8.1+ because `rails_blob_representation_proxy_url` is not mixed into `ActionView::Base`
- Access route helpers via `Rails.application.routes.url_helpers` instead of `respond_to?` on the view context
- Pass explicit `host` and `protocol` params since the module-level helpers don't have request context

## Context
In Rails 8.1, ActiveStorage route helpers are no longer mixed into ActionView::Base. The existing code checked `respond_to?(:rails_blob_representation_proxy_url)` on `self` (the view), which returned `false`, causing fallback to `url_for(variant)`. That call then failed because `VariantWithRecord` dropped `to_model` in Rails 8.1, resulting in all OG image tags being silently omitted.

## Test plan
- [ ] Verify `og:image` meta tag renders on pages with attached OG images
- [ ] Verify `og:image` meta tag renders on posts with attached OG images
- [ ] Verify `twitter:image` meta tag renders alongside OG image
- [ ] Check production logs no longer show "Failed to generate variant URL" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)