### PR TITLE
fix: Resolve DoubleRenderError and handle RecordNotFound in PostsController

### DIFF
--- a/app/controllers/panda/cms/posts_controller.rb
+++ b/app/controllers/panda/cms/posts_controller.rb
@@ -3,6 +3,8 @@
 module Panda
   module CMS
     class PostsController < ApplicationController
+      rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+
       before_action :set_default_ivars
 
       # TODO: Change from layout rendering to standard template rendering
@@ -34,7 +36,7 @@ module Panda
 
         # HTTP caching: Send ETag and Last-Modified headers for individual posts
         # Returns 304 Not Modified if client's cached version is still valid
-        fresh_when(@post, last_modified: @post.updated_at, public: true)
+        return unless stale?(@post, last_modified: @post.updated_at, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:show]
       end
@@ -48,7 +50,7 @@ module Panda
           .ordered
 
         latest_timestamp = @posts.maximum(:updated_at) || @post_category.updated_at
-        fresh_when(etag: [@post_category.cache_key_with_version, @posts.count, latest_timestamp], last_modified: latest_timestamp, public: true)
+        return unless stale?(etag: [@post_category.cache_key_with_version, @posts.count, latest_timestamp], last_modified: latest_timestamp, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:index]
       end
@@ -64,7 +66,7 @@ module Panda
         # HTTP caching: Use the most recent post in this month for conditional requests
         # Returns 304 Not Modified if no posts in this month have changed
         latest_month_timestamp = @posts.maximum(:updated_at) || @month
-        fresh_when(etag: [@month, @posts.count, latest_month_timestamp], last_modified: latest_month_timestamp, public: true)
+        return unless stale?(etag: [@month, @posts.count, latest_month_timestamp], last_modified: latest_month_timestamp, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:by_month]
       end
@@ -76,6 +78,10 @@ module Panda
       def set_default_ivars
         @page = nil
         @overrides = {}
+      end
+
+      def render_not_found
+        render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
       end
     end
   end

--- a/app/controllers/panda/cms/posts_controller.rb
+++ b/app/controllers/panda/cms/posts_controller.rb
@@ -65,7 +65,7 @@ module Panda
 
         # HTTP caching: Use the most recent post in this month for conditional requests
         # Returns 304 Not Modified if no posts in this month have changed
-        latest_month_timestamp = @posts.maximum(:updated_at) || @month
+        latest_month_timestamp = @posts.maximum(:updated_at) || @month.in_time_zone.beginning_of_day
         return unless stale?(etag: [@month, @posts.count, latest_month_timestamp], last_modified: latest_month_timestamp, public: true)
 
         render inline: "", layout: Panda::CMS.config.posts[:layouts][:by_month]
@@ -81,7 +81,7 @@ module Panda
       end
 
       def render_not_found
-        render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
+        render "panda/cms/errors/404", status: :not_found, layout: "error"
       end
     end
   end

--- a/spec/requests/panda/cms/posts_controller_spec.rb
+++ b/spec/requests/panda/cms/posts_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Posts", type: :request do
+  fixtures :panda_cms_posts, :panda_cms_post_categories
+
+  let(:admin) do
+    Panda::Core::User.find_or_create_by!(email: "admin@example.com") do |u|
+      u.name = "Admin User"
+      u.admin = true
+    end
+  end
+
+  before do
+    Panda::CMS::Post.find_each { |p| p.update!(user: admin, author: admin) }
+
+    # Configure post layouts for the dummy app (required for HTML rendering)
+    Panda::CMS.config.posts = Panda::CMS.config.posts.merge(
+      layouts: {show: "post", index: "page", by_month: "page"}
+    )
+  end
+
+  describe "GET /blog/:year/:month/:slug (show)" do
+    let(:post) { panda_cms_posts(:first_post) }
+    let(:year) { Time.current.strftime("%Y") }
+    let(:month) { Time.current.strftime("%m") }
+
+    context "when post does not exist" do
+      it "returns 404 for unknown slugs" do
+        get "/blog/#{year}/#{month}/nonexistent-post"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "renders the engine 404 page" do
+        get "/blog/#{year}/#{month}/nonexistent-post"
+        expect(response.body).to include("Page Not Found")
+      end
+    end
+
+    context "HTTP caching" do
+      it "returns ETag and Last-Modified headers" do
+        get "/blog/#{year}/#{month}/test-post-1"
+        expect(response.headers["ETag"]).to be_present
+        expect(response.headers["Last-Modified"]).to be_present
+      end
+
+      it "returns 304 Not Modified for cached requests" do
+        get "/blog/#{year}/#{month}/test-post-1"
+        etag = response.headers["ETag"]
+        last_modified = response.headers["Last-Modified"]
+
+        get "/blog/#{year}/#{month}/test-post-1",
+          headers: {"HTTP_IF_NONE_MATCH" => etag, "HTTP_IF_MODIFIED_SINCE" => last_modified}
+        expect(response).to have_http_status(:not_modified)
+      end
+
+      it "sets Cache-Control to public" do
+        get "/blog/#{year}/#{month}/test-post-1"
+        expect(response.headers["Cache-Control"]).to include("public")
+      end
+    end
+  end
+
+  describe "GET /blog/category/:category_slug (by_category)" do
+    context "when category does not exist" do
+      it "returns 404 for unknown categories" do
+        get "/blog/category/nonexistent-category"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replace `fresh_when` + unconditional `render` with `stale?` + `return unless` pattern in `show`, `by_category`, and `by_month` actions to prevent `AbstractController::DoubleRenderError` when clients send valid cache headers
- Add `rescue_from ActiveRecord::RecordNotFound` to render a clean 404 instead of letting exceptions propagate to error monitoring (bots/broken links hitting invalid blog slugs)
- The `index` action already used the correct `stale?` pattern — this aligns the other three actions

Fixes AppSignal incidents #237 (DoubleRenderError) and #45 (RecordNotFound) in neurobetter production.

## Test plan

- [ ] Verify `bundle exec rspec` passes in panda-cms
- [ ] Request a cached blog post with If-None-Match header — should return 304 without error
- [ ] Request `/blog/nonexistent-slug` — should return 404 cleanly
- [ ] Verify `by_category` and `by_month` pages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)