### PR TITLE
fix: Handle CSRF, bad request, and IP spoofing exceptions gracefully

### DIFF
--- a/app/controllers/panda/cms/application_controller.rb
+++ b/app/controllers/panda/cms/application_controller.rb
@@ -8,6 +8,9 @@ module Panda
 
       protect_from_forgery with: :exception
 
+      rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
+      rescue_from ActionController::BadRequest, with: :handle_bad_request
+
       # Add flash types for improved alert support with Tailwind
       add_flash_types :success, :warning, :error, :info
 
@@ -70,6 +73,17 @@ module Panda
 
       def user_signed_in?
         !!Panda::Core::Current.user
+      end
+
+      private
+
+      def handle_invalid_authenticity_token
+        redirect_back fallback_location: main_app.root_path,
+          flash: {error: "Your session has expired. Please try again."}
+      end
+
+      def handle_bad_request
+        head :bad_request
       end
     end
   end

--- a/app/controllers/panda/cms/pages_controller.rb
+++ b/app/controllers/panda/cms/pages_controller.rb
@@ -97,6 +97,9 @@ module Panda
           referer: request.referer, # TODO: Fix the naming of this column
           params: request.parameters
         )
+      rescue ActionDispatch::RemoteIp::IpSpoofAttackError
+        # Skip visit recording when IP headers conflict (e.g. multiple proxies).
+        # The page still renders normally — only the analytics record is lost.
       end
 
       def create_redirect_if_path_changed

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,4 +16,4 @@ pre-commit:
     - name: standardrb
       run: bundle exec standardrb
     - name: zeitwork
-      run: rake app:zeitwerk:check
+      run: bundle exec rake app:zeitwerk:check


### PR DESCRIPTION
## Summary

- Add `rescue_from InvalidAuthenticityToken` in `Panda::CMS::ApplicationController` to redirect with a "session expired" flash instead of raising a 500 (AppSignal incident #239)
- Add `rescue_from BadRequest` in `Panda::CMS::ApplicationController` returning 400 for malformed/spam requests with invalid encoding (AppSignal incident #264)
- Rescue `IpSpoofAttackError` in `PagesController#record_visit` to skip visit recording when IP headers conflict instead of crashing (AppSignal incident #201)
- Fix zeitwerk lefthook check to use `bundle exec`

## Test plan

- [x] Existing RSpec tests pass (27 examples, 0 failures)
- [x] All pre-commit hooks pass (brakeman, standardrb, erblint, bundle-audit, zeitwerk)
- [ ] Verify CSRF failures return redirect instead of 500
- [ ] Verify bad request spam returns 400 instead of 500
- [ ] Verify IP spoof errors no longer raise on page views

🤖 Generated with [Claude Code](https://claude.com/claude-code)